### PR TITLE
Improve <List> tests

### DIFF
--- a/app/components/List/tests/index.test.js
+++ b/app/components/List/tests/index.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { render } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import ListItem from 'components/ListItem';
 import List from '../index';
 
 describe('<List />', () => {
   it('should render the component if no items are passed', () => {
-    const renderedComponent = render(
+    const renderedComponent = shallow(
       <List component={ListItem} />
     );
     expect(renderedComponent.find(ListItem)).toBeDefined();
@@ -17,10 +17,11 @@ describe('<List />', () => {
       { id: 1, name: 'Hello' },
       { id: 2, name: 'World' },
     ];
-    const item = ({ name }) => <div>{name}</div>; // eslint-disable-line react/prop-types
-    const renderedComponent = render(
-      <List items={items} component={item} />
+
+    const renderedComponent = shallow(
+      <List items={items} component={ListItem} />
     );
-    expect(renderedComponent.find(items)).toBeDefined();
+    expect(renderedComponent.find(ListItem)).toBeDefined();
+    expect(renderedComponent.find(ListItem).length).toEqual(2);
   });
 });

--- a/app/components/List/tests/index.test.js
+++ b/app/components/List/tests/index.test.js
@@ -12,16 +12,19 @@ describe('<List />', () => {
     expect(renderedComponent.find(ListItem)).toBeDefined();
   });
 
-  it('should render the items', () => {
+  it('should pass all items props to rendered component', () => {
     const items = [
       { id: 1, name: 'Hello' },
       { id: 2, name: 'World' },
     ];
 
+    const component = ({ item }) => <ListItem>{item.name}</ListItem>; // eslint-disable-line react/prop-types
+
     const renderedComponent = shallow(
-      <List items={items} component={ListItem} />
+      <List items={items} component={component} />
     );
-    expect(renderedComponent.find(ListItem)).toBeDefined();
-    expect(renderedComponent.find(ListItem).length).toEqual(2);
+    expect(renderedComponent.find(component)).toHaveLength(2);
+    expect(renderedComponent.find(component).at(0).prop('item')).toBe(items[0]);
+    expect(renderedComponent.find(component).at(1).prop('item')).toBe(items[1]);
   });
 });


### PR DESCRIPTION
enzyme API document state that
to use `find()` in ReactWrapper,
the component must be rendered using `mount()` not `render()`

https://github.com/airbnb/enzyme/blob/master/docs/api/ReactWrapper/find.md
https://github.com/airbnb/enzyme/blob/master/docs/api/mount.md

reference https://github.com/mxstbr/react-boilerplate/issues/1119
