### PR TITLE
Add withMutations to ImmutableJS docs

### DIFF
--- a/docs/js/immutablejs.md
+++ b/docs/js/immutablejs.md
@@ -80,7 +80,7 @@ Because a new instance is created and returned each time a value is set or updat
 To avoid creating multiple instances of the data structure, we can utilise ImmutableJS's [`.withMutations`](https://facebook.github.io/immutable-js/docs/#/Map/withMutations), batching all of our changes in to a single mutation.
 
 ```JS
-const stateMap = Map({
+const stateMap = Map({ // eslint-disable-next-line new-cap
   a: 'A',
   b: 'B',
   c: 'C'

--- a/docs/js/immutablejs.md
+++ b/docs/js/immutablejs.md
@@ -74,31 +74,31 @@ const initialState = new StateRecord({}); // initialState is now a new StateReco
 
 Now, if you want to access `myData`, you can just write `state.myData` in your reducer code.
 
-## Making Complex Mutations Efficiently
+## Performance Tip: Batching Complex Mutations
 
 Because a new instance is created and returned each time a value is set or updated on an immutable data structure, complex mutations that aim to make changes to multiple parts of the data structure can cause a performance penalty.  
 To avoid creating multiple instances of the data structure, we can utilise ImmutableJS's [`.withMutations`](https://facebook.github.io/immutable-js/docs/#/Map/withMutations), batching all of our changes in to a single mutation.
 
 ```JS
 const stateMap = Map({
-    a: 'A',
-    b: 'B',
-    c: 'C'
+  a: 'A',
+  b: 'B',
+  c: 'C'
 });
 
 // Creates 3 new Map instances
 const newState = stateMap
-					.set('a', 1)
-					.set('b', 2)
-					.set('c', 3);
+	.set('a', 1)
+	.set('b', 2)
+	.set('c', 3);
 ...
 
 // Creates only 1 new Map instance - more performant
-const newState = stateMap.withMutations( intermediateState => {
+const newState = stateMap.withMutations((intermediateState) => {
 	intermediateState
 		.set('a', 1)
 		.set('b', 2)
-		.set('c', 3)
+		.set('c', 3);
 });				
 ```
 

--- a/docs/js/immutablejs.md
+++ b/docs/js/immutablejs.md
@@ -74,3 +74,33 @@ const initialState = new StateRecord({}); // initialState is now a new StateReco
 
 Now, if you want to access `myData`, you can just write `state.myData` in your reducer code.
 
+## Making Complex Mutations Efficiently
+
+Because a new instance is created and returned each time a value is set or updated on an immutable data structure, complex mutations that aim to make changes to multiple parts of the data structure can cause a performance penalty.  
+To avoid creating multiple instances of the data structure, we can utilise ImmutableJS's [`.withMutations`](https://facebook.github.io/immutable-js/docs/#/Map/withMutations), batching all of our changes in to a single mutation.
+
+```JS
+const stateMap = Map({
+    a: 'A',
+    b: 'B',
+    c: 'C'
+});
+
+// Creates 3 new Map instances
+const newState = stateMap
+					.set('a', 1)
+					.set('b', 2)
+					.set('c', 3);
+...
+
+// Creates only 1 new Map instance - more performant
+const newState = stateMap.withMutations( intermediateState => {
+	intermediateState
+		.set('a', 1)
+		.set('b', 2)
+		.set('c', 3)
+});				
+```
+
+From the [official docs](https://facebook.github.io/immutable-js/docs/#/Map/withMutations): 
+> Note: Not all methods can be used on a mutable collection or within withMutations! Only set and merge may be used mutatively. >


### PR DESCRIPTION
Hi All,
I've noticed a lot of .set().set().set() type chaining of ImmutableJS data structures over a number of projects - this approach is less than ideal performance-wise.  
I'm currently looking at adding something similar to the changes below to a project that I'm working on at the moment but thought that the community at large might benefit from being made aware of performance disadvantages of chaining multiple mutations and the solution that withMutations brings.

I also have another PR open for this particular file that fixes up some of the wording of the rest of the document... they can be landed irrespective of each other but it may be helpful to take a look at this one while reviewing this PR - #1126 
