### PR TITLE
Update templates and generators

### DIFF
--- a/internals/generators/component/es6.js.hbs
+++ b/internals/generators/component/es6.js.hbs
@@ -6,9 +6,9 @@
 
 import React from 'react';
 // import styled from 'styled-components';
-
 {{#if wantMessages}}
 import { FormattedMessage } from 'react-intl';
+
 import messages from './messages';
 {{/if}}
 

--- a/internals/generators/component/es6.pure.js.hbs
+++ b/internals/generators/component/es6.pure.js.hbs
@@ -6,9 +6,9 @@
 
 import React from 'react';
 // import styled from 'styled-components';
-
 {{#if wantMessages}}
 import { FormattedMessage } from 'react-intl';
+
 import messages from './messages';
 {{/if}}
 

--- a/internals/generators/component/stateless.js.hbs
+++ b/internals/generators/component/stateless.js.hbs
@@ -6,9 +6,9 @@
 
 import React from 'react';
 // import styled from 'styled-components';
-
 {{#if wantMessages}}
 import { FormattedMessage } from 'react-intl';
+
 import messages from './messages';
 {{/if}}
 

--- a/internals/generators/container/index.js.hbs
+++ b/internals/generators/container/index.js.hbs
@@ -14,6 +14,9 @@ import { FormattedMessage } from 'react-intl';
 {{/if}}
 {{#if wantActionsAndReducer}}
 import { createStructuredSelector } from 'reselect';
+{{/if}}
+
+{{#if wantActionsAndReducer}}
 import makeSelect{{properCase name}} from './selectors';
 {{/if}}
 {{#if wantMessages}}

--- a/internals/generators/container/reducer.js.hbs
+++ b/internals/generators/container/reducer.js.hbs
@@ -5,6 +5,7 @@
  */
 
 import { fromJS } from 'immutable';
+
 import {
   DEFAULT_ACTION,
 } from './constants';

--- a/internals/generators/container/reducer.test.js.hbs
+++ b/internals/generators/container/reducer.test.js.hbs
@@ -1,5 +1,6 @@
 
 import { fromJS } from 'immutable';
+
 import {{ camelCase name }}Reducer from '../reducer';
 
 describe('{{ camelCase name }}Reducer', () => {

--- a/internals/generators/container/sagas.test.js.hbs
+++ b/internals/generators/container/sagas.test.js.hbs
@@ -4,6 +4,7 @@
 
 /* eslint-disable redux-saga/yield-effects */
 // import { take, call, put, select } from 'redux-saga/effects';
+
 // import { defaultSaga } from '../sagas';
 
 // const generator = defaultSaga();

--- a/internals/generators/container/selectors.test.js.hbs
+++ b/internals/generators/container/selectors.test.js.hbs
@@ -1,4 +1,5 @@
 // import { fromJS } from 'immutable';
+
 // import { makeSelect{{ properCase name }}Domain } from '../selectors';
 
 // const selector = makeSelect{{ properCase name}}Domain();

--- a/internals/templates/appContainer.js
+++ b/internals/templates/appContainer.js
@@ -4,26 +4,20 @@
  *
  * This component is the skeleton around the actual pages, and should only
  * contain code that should be seen on all pages. (e.g. navigation bar)
- *
- * NOTE: while this component should technically be a stateless functional
- * component (SFC), hot reloading does not currently support SFCs. If hot
- * reloading is not a necessity for you then you can refactor it and remove
- * the linting exception.
  */
 
 import React from 'react';
 
-export default class App extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
-
-  static propTypes = {
-    children: React.PropTypes.node,
-  };
-
-  render() {
-    return (
-      <div>
-        {React.Children.toArray(this.props.children)}
-      </div>
-    );
-  }
+function App({ children }) {
+  return (
+    <div>
+      {React.Children.toArray(children)}
+    </div>
+  );
 }
+
+App.propTypes = {
+  children: React.PropTypes.node,
+};
+
+export default App;

--- a/internals/templates/homePage/homePage.js
+++ b/internals/templates/homePage/homePage.js
@@ -2,23 +2,19 @@
  * HomePage
  *
  * This is the first thing users see of our App, at the '/' route
- *
- * NOTE: while this component should technically be a stateless functional
- * component (SFC), hot reloading does not currently support SFCs. If hot
- * reloading is not a necessity for you then you can refactor it and remove
- * the linting exception.
  */
 
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
+
 import messages from './messages';
 
-export default class HomePage extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
-  render() {
-    return (
-      <h1>
-        <FormattedMessage {...messages.header} />
-      </h1>
-    );
-  }
+function HomePage() {
+  return (
+    <h1>
+      <FormattedMessage {...messages.header} />
+    </h1>
+  );
 }
+
+export default HomePage;

--- a/internals/templates/languageProvider/languageProvider.js
+++ b/internals/templates/languageProvider/languageProvider.js
@@ -13,14 +13,12 @@ import { IntlProvider } from 'react-intl';
 
 import { makeSelectLocale } from './selectors';
 
-export class LanguageProvider extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
-  render() {
-    return (
-      <IntlProvider locale={this.props.locale} key={this.props.locale} messages={this.props.messages[this.props.locale]}>
-        {React.Children.only(this.props.children)}
-      </IntlProvider>
-    );
-  }
+export function LanguageProvider({ locale, messages, children }) {
+  return (
+    <IntlProvider locale={locale} key={locale} messages={messages[locale]}>
+      {React.Children.only(children)}
+    </IntlProvider>
+  );
 }
 
 LanguageProvider.propTypes = {

--- a/internals/templates/notFoundPage/notFoundPage.js
+++ b/internals/templates/notFoundPage/notFoundPage.js
@@ -2,11 +2,6 @@
  * NotFoundPage
  *
  * This is the page we show when the user visits a url that doesn't have a route
- *
- * NOTE: while this component should technically be a stateless functional
- * component (SFC), hot reloading does not currently support SFCs. If hot
- * reloading is not a necessity for you then you can refactor it and remove
- * the linting exception.
  */
 
 import React from 'react';
@@ -14,12 +9,12 @@ import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
 
-export default class NotFound extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
-  render() {
-    return (
-      <h1>
-        <FormattedMessage {...messages.header} />
-      </h1>
-    );
-  }
+function NotFound() {
+  return (
+    <h1>
+      <FormattedMessage {...messages.header} />
+    </h1>
+  );
 }
+
+export default NotFound;


### PR DESCRIPTION
It is pretty confusing when you’re presented with text stating that these default container implementations aren’t SFC because they need to hot reload, but PureComponents doesn’t hot reload. If we've taken the step to bring them to PureComponent, then it feels like why not just take the final step and bring them to SFC.

Also, the spacing in the generated code didn't quite match the work done in #1275, so I added some to bring them in-line.