### PR TITLE
Alternative saga lifecycle

### DIFF
--- a/app/containers/HomePage/sagas.js
+++ b/app/containers/HomePage/sagas.js
@@ -2,8 +2,8 @@
  * Gets the repositories of the user from Github
  */
 
-import { take, call, put, select, cancel, takeLatest } from 'redux-saga/effects';
-import { LOCATION_CHANGE } from 'react-router-redux';
+import { fork, call, put, select } from 'redux-saga/effects';
+import { takeLatest } from 'redux-saga';
 import { LOAD_REPOS } from 'containers/App/constants';
 import { reposLoaded, repoLoadingError } from 'containers/App/actions';
 
@@ -27,18 +27,15 @@ export function* getRepos() {
   }
 }
 
+export function* repListen() {
+  yield* takeLatest(LOAD_REPOS, getRepos);
+}
 /**
  * Root saga manages watcher lifecycle
  */
 export function* githubData() {
   // Watches for LOAD_REPOS actions and calls getRepos when one comes in.
-  // By using `takeLatest` only the result of the latest API call is applied.
-  // It returns task descriptor (just like fork) so we can continue execution
-  const watcher = yield takeLatest(LOAD_REPOS, getRepos);
-
-  // Suspend execution until location changes
-  yield take(LOCATION_CHANGE);
-  yield cancel(watcher);
+  yield fork(repListen);
 }
 
 // Bootstrap sagas

--- a/app/containers/HomePage/sagas.js
+++ b/app/containers/HomePage/sagas.js
@@ -2,8 +2,7 @@
  * Gets the repositories of the user from Github
  */
 
-import { fork, call, put, select } from 'redux-saga/effects';
-import { takeLatest } from 'redux-saga';
+import { call, put, select, takeLatest } from 'redux-saga/effects';
 import { LOAD_REPOS } from 'containers/App/constants';
 import { reposLoaded, repoLoadingError } from 'containers/App/actions';
 
@@ -27,15 +26,12 @@ export function* getRepos() {
   }
 }
 
-export function* repListen() {
-  yield* takeLatest(LOAD_REPOS, getRepos);
-}
 /**
  * Root saga manages watcher lifecycle
  */
 export function* githubData() {
   // Watches for LOAD_REPOS actions and calls getRepos when one comes in.
-  yield fork(repListen);
+  yield takeLatest(LOAD_REPOS, getRepos);
 }
 
 // Bootstrap sagas

--- a/app/containers/HomePage/tests/sagas.test.js
+++ b/app/containers/HomePage/tests/sagas.test.js
@@ -2,10 +2,7 @@
  * Tests for HomePage sagas
  */
 
-import { cancel, take, put, takeLatest } from 'redux-saga/effects';
-import { createMockTask } from 'redux-saga/lib/utils';
-
-import { LOCATION_CHANGE } from 'react-router-redux';
+import { put, takeLatest } from 'redux-saga/effects';
 
 import { LOAD_REPOS } from 'containers/App/constants';
 import { reposLoaded, repoLoadingError } from 'containers/App/actions';
@@ -49,20 +46,9 @@ describe('getRepos Saga', () => {
 
 describe('githubDataSaga Saga', () => {
   const githubDataSaga = githubData();
-  const mockedTask = createMockTask();
 
   it('should start task to watch for LOAD_REPOS action', () => {
     const takeLatestDescriptor = githubDataSaga.next().value;
     expect(takeLatestDescriptor).toEqual(takeLatest(LOAD_REPOS, getRepos));
-  });
-
-  it('should yield until LOCATION_CHANGE action', () => {
-    const takeDescriptor = githubDataSaga.next(mockedTask).value;
-    expect(takeDescriptor).toEqual(take(LOCATION_CHANGE));
-  });
-
-  it('should cancel the forked task when LOCATION_CHANGE happens', () => {
-    const cancelDescriptor = githubDataSaga.next().value;
-    expect(cancelDescriptor).toEqual(cancel(mockedTask));
   });
 });

--- a/app/utils/asyncInjectors.js
+++ b/app/utils/asyncInjectors.js
@@ -62,7 +62,8 @@ export function injectAsyncSagas(store, isValid) {
       '(app/utils...) injectAsyncSagas: Received an empty `sagas` array'
     );
 
-    sagas.map(store.runSaga);
+    // return redux-saga Tasks, so they can be canceled on router events
+    return sagas.map(store.runSaga);
   };
 }
 

--- a/internals/generators/route/routeWithReducer.hbs
+++ b/internals/generators/route/routeWithReducer.hbs
@@ -2,23 +2,40 @@
       path: '{{ path }}',
       getComponent(nextState, cb) {
         const importModules = Promise.all([
-          import('containers/{{ properCase component }}/reducer'),
-          {{#if useSagas}}
-          import('containers/{{ properCase component }}/sagas'),
-          {{/if}}
-          import('containers/{{ properCase component }}'),
+          System.import('containers/{{ properCase component }}/reducer'),
+          System.import('containers/{{ properCase component }}'),
         ]);
 
         const renderRoute = loadModule(cb);
 
-        importModules.then(([reducer,{{#if useSagas}} sagas,{{/if}} component]) => {
+        importModules.then(([reducer, component]) => {
           injectReducer('{{ camelCase component }}', reducer.default);
-          {{#if useSagas}}
-          injectSagas(sagas.default);
-          {{/if}}
           renderRoute(component);
         });
 
         importModules.catch(errorLoading);
       },
+      {{#if useSagas}}
+      onEnter(nextState, replace, callback) {
+        if (this.loadedSagas) {
+          callback();
+          return;
+        }
+
+        const importModules = System.import('containers/{{ properCase component }}/sagas');
+
+        importModules.then((sagas) => {
+          this.loadedSagas = injectSagas(sagas.default);
+          callback();
+        });
+
+        importModules.catch(errorLoading);
+      },
+      onLeave() {
+        if (this.loadedSagas) {
+          this.loadedSagas.forEach((saga) => saga.cancel());
+          delete this.loadedSagas;
+        }
+      },
+      {{/if}}
     },$1


### PR DESCRIPTION
This is a proof of concept demonstrating an alternative saga lifecycle management.

Lets suppose we have the following routing scheme:
```
/tree/branches/ -> BranchPage container
/tree/branches/:branchId 
/tree/about -> AboutPage container
```
And we require:
1. The `BranchPage` sagas should be injected and started when the user enters `/tree/branches/*` from `/tree/about` or any other path.
2. The `BranchPage` sagas should be canceled when the user leaves from `/tree/branches/*` to any other path like `/tree/about`.
3. The `BranchPage` container sagas keep running (without interruption/reinjection) while the user is on a `/tree/branches/*` path even when he jumps between different branch ids `/tree/branches/branch1`, `/tree/branches/branch2` etc.

This can be achieved by injecting the route `BranchPage` sagas on `onEnter` and canceling them on `onLeave` route events of the `/tree/branches/*` route.
For this we modify the `injectAsyncSagas` method to return our sagas Tasks. After that we can fully manage our sagas from `app/routes.js`.
Note that this also allows us to have global per app sagas for the root path `/*`.

To keep it simple this PR demonstrates this approach on the boilerplate default Example app.

The tests\generators\templates have been updated accordingly.