### PR TITLE
Docs: Add JS guidelines doc with first few rules explained

### DIFF
--- a/docs/js/guidlines.md
+++ b/docs/js/guidlines.md
@@ -1,0 +1,60 @@
+# JavaScript Style Guidelines
+
+React Boilerplate subscribes to AirBnB's well established [JavaScript](https://github.com/airbnb/javascript) and [React](https://github.com/airbnb/javascript/tree/master/react) style guides with a few tweaks
+
+These tweaks are defined in the [`package.json`](../../tree/master/package.json) and some are explained throughout this document.
+
+While it's good practice to follow a common code style, the most important thing is that you and your team agree on a consistant coding style. The default style guides included here in React Boilerplate are highly recommended, but if your team would like to change some rules - feel free to do so!
+
+## Overrides
+
+### arrow-parens 
+
+eslint: [`arrow-parens`](http://eslint.org/docs/rules/arrow-parens)
+
+> Why? Not sure
+
+```js
+// Bad
+a => {}
+
+// Good
+(a) => {}
+```
+
+### arrow-body-style 
+
+eslint: [`arrow-body-style `](http://eslint.org/docs/rules/arrow-body-style)
+
+> Why? In cases where a function returns a single expression the function block and explicit return statement can be ommited, leaving just the expression.
+
+```js
+// Bad
+const foo = () => {
+    return 'something';
+};
+
+// Good
+const foo = () => 'something';
+```
+
+### comma-dangle
+
+eslint: [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle) 
+
+> Why? Adding trailing commas to multiline object & array literals helps keep diffs clean since adding or removing items does not require adding or removing an extra comma to otherwise untouched lines as in the following example diffs:
+
+```diff
+// Bad
+const foo = {
+-   bar: 'baz',
+-   qux: 'quux'
++   bar: 'baz'
+};
+
+// Good
+const foo = {
+    bar: 'baz',
+-   qux: 'quux',
+};
+```


### PR DESCRIPTION
As talked about in #1213, here is a 'first draft' of a JS style guide doc.
I've only added a few explanations of deviations from AirBnB for now - more could be added over time, whether that's before or after a merge.

I realise that I might not be in the best position to really see this through on my own, mostly because my time has been spent working on non RBP projects for some months now 😕
Also, there are eslint rules that I'm not so sure about and so can't write accurate justifications for them.

Happy to hand this over, let it go (if it's not deemed important) or just work with others who know better than I do - what ever works best! 🙂