### PR TITLE
Move root route configuration to routes.js, add documentation for creating a global saga

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -18,9 +18,6 @@ import FontFaceObserver from 'fontfaceobserver';
 import { useScroll } from 'react-router-scroll';
 import 'sanitize.css/sanitize.css';
 
-// Import root app
-import App from 'containers/App';
-
 // Import selector for `syncHistoryWithStore`
 import { makeSelectLocationState } from 'containers/App/selectors';
 
@@ -71,10 +68,6 @@ const history = syncHistoryWithStore(browserHistory, store, {
 });
 
 // Set up the router, wrapping all Routes in the App component
-const rootRoute = {
-  component: App,
-  childRoutes: createRoutes(store),
-};
 
 const render = (messages) => {
   ReactDOM.render(
@@ -82,7 +75,7 @@ const render = (messages) => {
       <LanguageProvider messages={messages}>
         <Router
           history={history}
-          routes={rootRoute}
+          routes={createRoutes(store)}
           render={
             // Scroll to top when going to a new page, imitating default browser
             // behaviour

--- a/app/routes.js
+++ b/app/routes.js
@@ -16,44 +16,60 @@ export default function createRoutes(store) {
   // create reusable async injectors using getAsyncInjectors factory
   const { injectReducer, injectSagas } = getAsyncInjectors(store);
 
-  return [
-    {
-      path: '/',
-      name: 'home',
-      getComponent(nextState, cb) {
-        const importModules = Promise.all([
-          import('containers/HomePage/reducer'),
-          import('containers/HomePage/sagas'),
-          import('containers/HomePage'),
-        ]);
+  return {
+    getComponent(nextState, cb) {
+      const importModules = Promise.all([
+        import('containers/App'),
+      ]);
 
-        const renderRoute = loadModule(cb);
+      const renderRoute = loadModule(cb);
 
-        importModules.then(([reducer, sagas, component]) => {
-          injectReducer('home', reducer.default);
-          injectSagas(sagas.default);
+      importModules.then(([sagas, component]) => {
+        injectSagas(sagas.default);
+      renderRoute(component);
+    });
 
-          renderRoute(component);
-        });
-
-        importModules.catch(errorLoading);
-      },
-    }, {
-      path: '/features',
-      name: 'features',
-      getComponent(nextState, cb) {
-        import('containers/FeaturePage')
-          .then(loadModule(cb))
-          .catch(errorLoading);
-      },
-    }, {
-      path: '*',
-      name: 'notfound',
-      getComponent(nextState, cb) {
-        import('containers/NotFoundPage')
-          .then(loadModule(cb))
-          .catch(errorLoading);
-      },
+      importModules.catch(errorLoading);
     },
-  ];
+    childRoutes: [
+      {
+        path: '/',
+        name: 'home',
+        getComponent(nextState, cb) {
+          const importModules = Promise.all([
+            import('containers/HomePage/reducer'),
+            import('containers/HomePage/sagas'),
+            import('containers/HomePage'),
+          ]);
+
+          const renderRoute = loadModule(cb);
+
+          importModules.then(([reducer, sagas, component]) => {
+            injectReducer('home', reducer.default);
+            injectSagas(sagas.default);
+
+            renderRoute(component);
+          });
+
+          importModules.catch(errorLoading);
+        },
+      }, {
+        path: '/features',
+        name: 'features',
+        getComponent(nextState, cb) {
+          import('containers/FeaturePage')
+            .then(loadModule(cb))
+            .catch(errorLoading);
+        },
+      }, {
+        path: '*',
+        name: 'notfound',
+        getComponent(nextState, cb) {
+          import('containers/NotFoundPage')
+            .then(loadModule(cb))
+            .catch(errorLoading);
+        },
+      },
+    ]
+  };
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -26,8 +26,9 @@ export default function createRoutes(store) {
 
       importModules.then(([sagas, component]) => {
         injectSagas(sagas.default);
-      renderRoute(component);
-    });
+
+        renderRoute(component);
+      });
 
       importModules.catch(errorLoading);
     },
@@ -70,6 +71,6 @@ export default function createRoutes(store) {
             .catch(errorLoading);
         },
       },
-    ]
+    ],
   };
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@
   - [ImmutableJS](js/immutablejs.md)
   - [reselect](js/reselect.md)
   - [redux-saga](js/redux-saga.md)
+  - [global saga](js/global-saga.md)
   - [i18n](js/i18n.md)
   - [routing](js/routing.md)
 

--- a/docs/js/README.md
+++ b/docs/js/README.md
@@ -23,6 +23,7 @@ add new parts of your application!
 - [ImmutableJS](immutablejs.md)
 - [reselect](reselect.md)
 - [redux-saga](redux-saga.md)
+- [global saga](global-saga.md)
 - [react-intl](i18n.md)
 - [routing](routing.md)
 

--- a/docs/js/global-saga.md
+++ b/docs/js/global-saga.md
@@ -1,0 +1,61 @@
+# `global saga`
+
+A global saga is an app level saga. The built-in example of sagas in this app are all contained within child containers that get put inside the `App` container. The app container by itself is pretty basic, allowing for all the action to happen within it's child containers; however, sometimes that's just not enough. Imagine the following scenario if you will.
+
+> You have an app that upon loading needs to grab data from the server, regardless of which route the user entered. You could put a function inside the `onComponentMount` of every single container, but that's not very DRY. What you end up with is a lot of duplicate constants, actions, and reducers.
+> 
+> Enter the global saga. A way to load up a `sagas.js` file for the `App` container.
+
+## Usage
+
+We'll be doing the following:
+
+1. Adding `sagas.js` to `app/containers/App` directory
+2. importing `sagas.js` into the App container route configuration
+
+Like other sagas, your global saga will live within a container, the `App` container. Go ahead and add a file and use the following starter code; it's the same starter code for other sagas.
+
+######app/containers/App/sagas.js
+```JS
+import { take, call, put, select } from 'redux-saga/effects';
+
+// Your sagas for this container
+export default [
+  sagaName,
+];
+
+// Individual exports for testing
+export function* sagaName() {
+
+}
+```
+
+Next we'll import the `sagas.js` file into our `App` route configuration
+######app/routes.js
+```JS
+export default function createRoutes(store) {
+  // create reusable async injectors using getAsyncInjectors factory
+  const { injectReducer, injectSagas } = getAsyncInjectors(store);
+
+  return {
+    getComponent(nextState, cb) {
+      const importModules = Promise.all([
+        import('containers/App/sagas'),
+        import('containers/App'),
+      ]);
+
+      const renderRoute = loadModule(cb);
+
+      importModules.then(([sagas, component]) => {
+        injectSagas(sagas.default);
+        renderRoute(component);
+      });
+
+      importModules.catch(errorLoading);
+    },
+    childRoutes: [
+      // All your child routes are here inside this array
+    ]
+  }
+}
+```

--- a/internals/generators/route/route.hbs
+++ b/internals/generators/route/route.hbs
@@ -2,7 +2,7 @@
         path: '{{ path }}',
         name: '{{ camelCase component }}',
         getComponent(location, cb) {
-          System.import('{{{directory (properCase component)}}}')
+          import('{{{directory (properCase component)}}}')
             .then(loadModule(cb))
             .catch(errorLoading);
         },

--- a/internals/generators/route/route.hbs
+++ b/internals/generators/route/route.hbs
@@ -1,9 +1,9 @@
  {
-      path: '{{ path }}',
-      name: '{{ camelCase component }}',
-      getComponent(location, cb) {
-        import('{{{directory (properCase component)}}}')
-          .then(loadModule(cb))
-          .catch(errorLoading);
-      },
-    },$1
+        path: '{{ path }}',
+        name: '{{ camelCase component }}',
+        getComponent(location, cb) {
+          System.import('{{{directory (properCase component)}}}')
+            .then(loadModule(cb))
+            .catch(errorLoading);
+        },
+      },$1

--- a/internals/generators/route/routeWithReducer.hbs
+++ b/internals/generators/route/routeWithReducer.hbs
@@ -1,25 +1,25 @@
  {
-      path: '{{ path }}',
-      name: '{{ camelCase component }}',
-      getComponent(nextState, cb) {
-        const importModules = Promise.all([
-          import('containers/{{ properCase component }}/reducer'),
-          {{#if useSagas}}
-          import('containers/{{ properCase component }}/sagas'),
-          {{/if}}
-          import('containers/{{ properCase component }}'),
-        ]);
+        path: '{{ path }}',
+        name: '{{ camelCase component }}',
+        getComponent(nextState, cb) {
+          const importModules = Promise.all([
+            import('containers/{{ properCase component }}/reducer'),
+            {{#if useSagas}}
+            import('containers/{{ properCase component }}/sagas'),
+            {{/if}}
+            import('containers/{{ properCase component }}'),
+          ]);
 
-        const renderRoute = loadModule(cb);
+          const renderRoute = loadModule(cb);
 
-        importModules.then(([reducer,{{#if useSagas}} sagas,{{/if}} component]) => {
-          injectReducer('{{ camelCase component }}', reducer.default);
-          {{#if useSagas}}
-          injectSagas(sagas.default);
-          {{/if}}
-          renderRoute(component);
-        });
+          importModules.then(([reducer,{{#if useSagas}} sagas,{{/if}} component]) => {
+            injectReducer('{{ camelCase component }}', reducer.default);
+            {{#if useSagas}}
+            injectSagas(sagas.default);
+            {{/if}}
+            renderRoute(component);
+          });
 
-        importModules.catch(errorLoading);
-      },
-    },$1
+          importModules.catch(errorLoading);
+        },
+      },$1


### PR DESCRIPTION
The route configuration was previously split between `app.js` and `routes.js`. I've moved the `App` (rootRoute) configuration to the `routes.js` file, so it is all in one place. I also changed loading the root route to use `getComponent`, instead of `component`, to make it easier for people to implement a global saga if they want to do that. There is also new documentation on how to add a global saga. I've also updated the spacing for the route generators and tested them.