### PR TITLE
test(build:clean script): remove test:clean from build:clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "postinstall": "npm run build:dll",
     "prebuild": "npm run build:clean",
     "build": "cross-env NODE_ENV=production webpack --config internals/webpack/webpack.prod.babel.js --color -p --progress --hide-modules",
-    "build:clean": "npm run test:clean && rimraf ./build",
+    "build:clean": "rimraf ./build",
     "build:dll": "node ./internals/scripts/dependencies.js",
     "start": "cross-env NODE_ENV=development node server",
     "start:tunnel": "cross-env NODE_ENV=development ENABLE_TUNNEL=true node server",


### PR DESCRIPTION
Fixes coveralls reporting?

Discussion in #1535 

#1432 is implicated in the recent failure of Coveralls reporting.

#1432 sought to separate `test` and `build` scripts, but erroneously left `test:clean` in `build:clean`. 

The effect being that 

- `test` built  `./coverage`
- `build` removed `./coverage`
- `coveralls` failed for lack of `./coverage` 

This PR fixxes that error.