### PR TITLE
Fix team of developers link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 <br />
 
 <div align="center">
-  <sub>Created by <a href="https://twitter.com/mxstbr">Max Stoiber</a> and maintained with ❤️ by an amazing <a href="https://github.com/orgs/react-boilerplate/teams/core">team of developers</a>.</sub>
+  <sub>Created by <a href="https://twitter.com/mxstbr">Max Stoiber</a> and maintained with ❤️ by an amazing <a href="https://github.com/orgs/react-boilerplate/people">team of developers</a>.</sub>
 </div>
 
 ## Features


### PR DESCRIPTION
The current "team of developers" link in the README file is only accessible to authorized users, as reported in #1564.

This PR changes the URL so it is publically accessible. Please note that this link will ONLY show members that have publicized their organization membership. It seems the default is Private, but you can this via the instructions in the link below (I just changed mine).
https://help.github.com/articles/publicizing-or-hiding-organization-membership/