### PR TITLE
Docs Readme: Fix missing reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
   - [Introduction ](general/introduction.md)
   - [Tool Configuration](general/files.md)
   - [Server Configurations](general/server-configs.md)
-  - [Deployment](general/deployment.md) *(currently Heroku specific)*
+  - [Deployment](general/deployment.md) *(currently Heroku and AWS S3 specific)*
   - [FAQ](general/faq.md)
   - [Gotchas](general/gotchas.md)
   - [Remove](general/remove.md)


### PR DESCRIPTION
PR #1442 added AWS documentation but didn't update the Readme text.