### PR TITLE
Remove state update in componentWillUpdate

### DIFF
--- a/app/components/ProgressBar/index.js
+++ b/app/components/ProgressBar/index.js
@@ -29,12 +29,12 @@ function withProgressBar(WrappedComponent) {
       }
     }
 
-    componentWillUpdate(newProps, newState) {
+    componentWillReceiveProps(newProps) {
       const { loadedRoutes, progress } = this.state;
       const { pathname } = newProps.location;
 
       // Complete progress when route changes. But prevent state update while re-rendering.
-      if (loadedRoutes.indexOf(pathname) === -1 && progress !== -1 && newState.progress < 100) {
+      if (loadedRoutes.indexOf(pathname) === -1 && progress !== -1 && progress < 100) {
         this.updateProgress(100);
         this.setState({
           loadedRoutes: loadedRoutes.concat([pathname]),


### PR DESCRIPTION
This PR removes the `setState()` in `componentWillUpdate` of the ProgressBar component.
See React.Component [componentwillupdate](https://facebook.github.io/react/docs/react-component.html#componentwillupdate) documentation.

