### PR TITLE
Request utils: handle 204 and 205 HTTP response

### DIFF
--- a/app/utils/request.js
+++ b/app/utils/request.js
@@ -8,6 +8,9 @@ import 'whatwg-fetch';
  * @return {object}          The parsed JSON from the request
  */
 function parseJSON(response) {
+  if (response.status === 204 || response.status === 205) {
+    return null;
+  }
   return response.json();
 }
 

--- a/app/utils/tests/request.test.js
+++ b/app/utils/tests/request.test.js
@@ -33,6 +33,27 @@ describe('request', () => {
     });
   });
 
+  describe('stubbing 204 response', () => {
+    // Before each test, pretend we got a successful response
+    beforeEach(() => {
+      const res = new Response('', {
+        status: 204,
+        statusText: 'No Content',
+      });
+
+      window.fetch.mockReturnValue(Promise.resolve(res));
+    });
+
+    it('should return null on 204 response', (done) => {
+      request('/thisurliscorrect')
+        .catch(done)
+        .then((json) => {
+          expect(json).toBeNull();
+          done();
+        });
+    });
+  });
+
   describe('stubbing error response', () => {
     // Before each test, pretend we got an unsuccessful response
     beforeEach(() => {


### PR DESCRIPTION
As mentionned in [this issue](https://github.com/react-boilerplate/react-boilerplate/issues/1774), the `request` utils fails when it receive a 204 or 205 HTTP response, as it is trying to parse an empty string (the body) into JSON.

This pull request allows `request` to handle those response by returning a `null`.