### PR TITLE
Migrating from React.PropTypes to PropTypes

### DIFF
--- a/app/components/Button/index.js
+++ b/app/components/Button/index.js
@@ -6,7 +6,8 @@
  * otherwise it'll render a link with an onclick
  */
 
-import React, { PropTypes, Children } from 'react';
+import React, { Children } from 'react';
+import PropTypes from 'prop-types';
 
 import A from './A';
 import StyledButton from './StyledButton';

--- a/app/components/Img/index.js
+++ b/app/components/Img/index.js
@@ -5,7 +5,8 @@
  * Renders an image, enforcing the usage of the alt="" tag
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 function Img(props) {
   return (

--- a/app/components/IssueIcon/index.js
+++ b/app/components/IssueIcon/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 function IssueIcon(props) {
   return (
@@ -13,7 +14,7 @@ function IssueIcon(props) {
 }
 
 IssueIcon.propTypes = {
-  className: React.PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default IssueIcon;

--- a/app/components/List/index.js
+++ b/app/components/List/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Ul from './Ul';
 import Wrapper from './Wrapper';
@@ -27,8 +28,8 @@ function List(props) {
 }
 
 List.propTypes = {
-  component: React.PropTypes.func.isRequired,
-  items: React.PropTypes.array,
+  component: PropTypes.func.isRequired,
+  items: PropTypes.array,
 };
 
 export default List;

--- a/app/components/ListItem/index.js
+++ b/app/components/ListItem/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Item from './Item';
 import Wrapper from './Wrapper';
@@ -14,7 +15,7 @@ function ListItem(props) {
 }
 
 ListItem.propTypes = {
-  item: React.PropTypes.any,
+  item: PropTypes.any,
 };
 
 export default ListItem;

--- a/app/components/LoadingIndicator/Circle.js
+++ b/app/components/LoadingIndicator/Circle.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import styled, { keyframes } from 'styled-components';
 
 const circleFadeDelay = keyframes`

--- a/app/components/ProgressBar/ProgressBar.js
+++ b/app/components/ProgressBar/ProgressBar.js
@@ -4,7 +4,8 @@
  *
 */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Wrapper from './Wrapper';
 import Percent from './Percent';
 

--- a/app/components/ProgressBar/index.js
+++ b/app/components/ProgressBar/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ProgressBar from './ProgressBar';
 
 function withProgressBar(WrappedComponent) {
@@ -59,8 +60,8 @@ function withProgressBar(WrappedComponent) {
   }
 
   AppWithProgressBar.propTypes = {
-    location: React.PropTypes.object,
-    router: React.PropTypes.object,
+    location: PropTypes.object,
+    router: PropTypes.object,
   };
 
   return AppWithProgressBar;

--- a/app/components/ReposList/index.js
+++ b/app/components/ReposList/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import List from 'components/List';
 import ListItem from 'components/ListItem';

--- a/app/components/Toggle/index.js
+++ b/app/components/Toggle/index.js
@@ -5,6 +5,7 @@
 */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Select from './Select';
 import ToggleOption from '../ToggleOption';
@@ -27,10 +28,10 @@ function Toggle(props) {
 }
 
 Toggle.propTypes = {
-  onToggle: React.PropTypes.func,
-  values: React.PropTypes.array,
-  value: React.PropTypes.string,
-  messages: React.PropTypes.object,
+  onToggle: PropTypes.func,
+  values: PropTypes.array,
+  value: PropTypes.string,
+  messages: PropTypes.object,
 };
 
 export default Toggle;

--- a/app/components/ToggleOption/index.js
+++ b/app/components/ToggleOption/index.js
@@ -5,6 +5,7 @@
 */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from 'react-intl';
 
 const ToggleOption = ({ value, message, intl }) => (
@@ -14,8 +15,8 @@ const ToggleOption = ({ value, message, intl }) => (
 );
 
 ToggleOption.propTypes = {
-  value: React.PropTypes.string.isRequired,
-  message: React.PropTypes.object,
+  value: PropTypes.string.isRequired,
+  message: PropTypes.object,
   intl: intlShape.isRequired,
 };
 

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import styled from 'styled-components';
 
@@ -41,7 +42,7 @@ export function App(props) {
 }
 
 App.propTypes = {
-  children: React.PropTypes.node,
+  children: PropTypes.node,
 };
 
 export default withProgressBar(App);

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
@@ -86,18 +87,18 @@ export class HomePage extends React.PureComponent { // eslint-disable-line react
 }
 
 HomePage.propTypes = {
-  loading: React.PropTypes.bool,
-  error: React.PropTypes.oneOfType([
-    React.PropTypes.object,
-    React.PropTypes.bool,
+  loading: PropTypes.bool,
+  error: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.bool,
   ]),
-  repos: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.bool,
+  repos: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.bool,
   ]),
-  onSubmitForm: React.PropTypes.func,
-  username: React.PropTypes.string,
-  onChangeUsername: React.PropTypes.func,
+  onSubmitForm: PropTypes.func,
+  username: PropTypes.string,
+  onChangeUsername: PropTypes.func,
 };
 
 export function mapDispatchToProps(dispatch) {

--- a/app/containers/LanguageProvider/index.js
+++ b/app/containers/LanguageProvider/index.js
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { IntlProvider } from 'react-intl';
@@ -24,9 +25,9 @@ export class LanguageProvider extends React.PureComponent { // eslint-disable-li
 }
 
 LanguageProvider.propTypes = {
-  locale: React.PropTypes.string,
-  messages: React.PropTypes.object,
-  children: React.PropTypes.element.isRequired,
+  locale: PropTypes.string,
+  messages: PropTypes.object,
+  children: PropTypes.element.isRequired,
 };
 
 const mapStateToProps = createSelector(

--- a/app/containers/LocaleToggle/index.js
+++ b/app/containers/LocaleToggle/index.js
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
@@ -26,8 +27,8 @@ export class LocaleToggle extends React.PureComponent { // eslint-disable-line r
 }
 
 LocaleToggle.propTypes = {
-  onLocaleToggle: React.PropTypes.func,
-  locale: React.PropTypes.string,
+  onLocaleToggle: PropTypes.func,
+  locale: PropTypes.string,
 };
 
 const mapStateToProps = createSelector(

--- a/app/containers/RepoListItem/index.js
+++ b/app/containers/RepoListItem/index.js
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { FormattedNumber } from 'react-intl';
@@ -48,8 +49,8 @@ export class RepoListItem extends React.PureComponent { // eslint-disable-line r
 }
 
 RepoListItem.propTypes = {
-  item: React.PropTypes.object,
-  currentUser: React.PropTypes.string,
+  item: PropTypes.object,
+  currentUser: PropTypes.string,
 };
 
 export default connect(createStructuredSelector({

--- a/internals/generators/container/class.js.hbs
+++ b/internals/generators/container/class.js.hbs
@@ -4,7 +4,8 @@
  *
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 {{#if wantHeaders}}
 import Helmet from 'react-helmet';

--- a/internals/generators/container/index.js.hbs
+++ b/internals/generators/container/index.js.hbs
@@ -4,7 +4,8 @@
  *
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 {{#if wantHeaders}}
 import Helmet from 'react-helmet';

--- a/internals/generators/container/stateless.js.hbs
+++ b/internals/generators/container/stateless.js.hbs
@@ -4,7 +4,8 @@
 *
 */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 {{#if wantHeaders}}
 import Helmet from 'react-helmet';

--- a/internals/templates/containers/App/index.js
+++ b/internals/templates/containers/App/index.js
@@ -12,11 +12,12 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class App extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
 
   static propTypes = {
-    children: React.PropTypes.node,
+    children: PropTypes.node,
   };
 
   render() {

--- a/internals/templates/containers/LanguageProvider/index.js
+++ b/internals/templates/containers/LanguageProvider/index.js
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { IntlProvider } from 'react-intl';
@@ -24,9 +25,9 @@ export class LanguageProvider extends React.PureComponent { // eslint-disable-li
 }
 
 LanguageProvider.propTypes = {
-  locale: React.PropTypes.string,
-  messages: React.PropTypes.object,
-  children: React.PropTypes.element.isRequired,
+  locale: PropTypes.string,
+  messages: PropTypes.object,
+  children: PropTypes.element.isRequired,
 };
 
 

--- a/package.json
+++ b/package.json
@@ -226,6 +226,7 @@
     "ip": "1.1.4",
     "lodash": "4.17.4",
     "minimist": "1.2.0",
+    "prop-types": "15.5.10",
     "react": "15.4.2",
     "react-dom": "15.4.2",
     "react-helmet": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6064,7 +6064,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4:
+prop-types@15.5.10, prop-types@^15.5.4:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:


### PR DESCRIPTION
`React.PropType` will be deprecated in future releases in favor of `prop-types` package.

From React's website:

> Prop types are a feature for runtime validation of props during development. We've extracted the built-in prop types to a separate package to reflect the fact that not everybody uses them.
> 
> In 15.5, instead of accessing PropTypes from the main React object, install the prop-types package and import them from there

More info at [this link](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes)
