### PR TITLE
Add babel-polyfill entry to webpack prod config.

### DIFF
--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -7,6 +7,7 @@ const OfflinePlugin = require('offline-plugin');
 module.exports = require('./webpack.base.babel')({
   // In production, we skip all hot-reloading stuff
   entry: [
+    'babel-polyfill',
     path.join(process.cwd(), 'app/app.js'),
   ],
 


### PR DESCRIPTION
When doing a production build babel-polyfill will be loaded on entry.  A problem occurs when performing a production build (specifically `npm run start:production` or `npm run build`).  This fixes an error caused by the lack of `Symbol()` support in IE11.

Edit:

Additionally, Babel lists this as a requirement in their documentation.  See [here](https://babeljs.io/docs/usage/polyfill/#usage-in-node-browserify-webpack).