### PR TITLE
Fix plain CSS include

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -24,7 +24,7 @@ module.exports = (options) => ({
       // they will be a part of our compilation either way.
       // So, no need for ExtractTextPlugin here.
       test: /\.css$/,
-      include: /node_modules/,
+      exclude: /node_modules/,
       loaders: ['style-loader', 'css-loader'],
     }, {
       test: /\.(eot|svg|ttf|woff|woff2)$/,

--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -24,7 +24,7 @@ module.exports = (options) => ({
       // they will be a part of our compilation either way.
       // So, no need for ExtractTextPlugin here.
       test: /\.css$/,
-      exclude: /node_modules/,
+      include: [/node_modules/, /app/],
       loaders: ['style-loader', 'css-loader'],
     }, {
       test: /\.(eot|svg|ttf|woff|woff2)$/,


### PR DESCRIPTION
Hi everyone. First off - awesome boilerplate!

I've encountered a small issue with importing plain `.css`, getting  
*“You may need an appropriate loader to handle this file type” with Webpack and CSS* error  

Simply changing include to exclude in webpack config solved it for me.
Plus following [SAAS guide](https://github.com/react-boilerplate/react-boilerplate/blob/master/docs/css/sass.md) it uses exclude (and it's only logical to exclude node modules).

So it seems like a simple typo, that's why I opened a PR without an issue, hope it's ok.
Checked all 3 branches and open PRs, seems no one has addressed it before (guessing not many people still use plain CSS :)