### PR TITLE
chore(deps): downgrade `sanitize.css`

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "redux-immutable": "4.0.0",
     "redux-saga": "0.15.3",
     "reselect": "3.0.1",
-    "sanitize.css": "5.0.0",
+    "sanitize.css": "4.1.0",
     "styled-components": "2.0.0",
     "warning": "3.0.0",
     "whatwg-fetch": "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6879,9 +6879,9 @@ sane@~1.6.0:
     walker "~1.0.5"
     watch "~0.10.0"
 
-sanitize.css@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/sanitize.css/-/sanitize.css-5.0.0.tgz#84184b40678f72bb8898c768a27be7578257271a"
+sanitize.css@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/sanitize.css/-/sanitize.css-4.1.0.tgz#0bafc3c513699f2fe8c7980c6d37edf21d3f5448"
 
 sax@^1.2.1, sax@~1.2.1:
   version "1.2.4"


### PR DESCRIPTION
`sanitize.css` adds `background: transparent` to inputs thus making them loose their native styling (as was pointed out by @vicbell) for no good reason, [the fix was merged](https://github.com/jonathantneal/sanitize.css/pull/137) but not yet released so for the time being I propose to downgrade `sanitize.css` to 4.1.0.