### PR TITLE
Use camelcase for generated reducer and saga key to match selector.

### DIFF
--- a/internals/generators/container/class.js.hbs
+++ b/internals/generators/container/class.js.hbs
@@ -70,12 +70,12 @@ function mapDispatchToProps(dispatch) {
 {{#if wantActionsAndReducer}}
 const withConnect = connect(mapStateToProps, mapDispatchToProps);
 
-const withReducer = injectReducer({ key: '{{ lowerCase name }}', reducer });
+const withReducer = injectReducer({ key: '{{ camelCase name }}', reducer });
 {{else}}
 const withConnect = connect(null, mapDispatchToProps);
 {{/if}}
 {{#if wantSaga}}
-const withSaga = injectSaga({ key: '{{ lowerCase name }}', saga });
+const withSaga = injectSaga({ key: '{{ camelCase name }}', saga });
 {{/if}}
 
 export default compose(


### PR DESCRIPTION
Currently, the reducer key does not match the key generated for the selector, so generated containers don't work. This PR makes the reducer key match, and updates the saga key as well for consistency.

## React Boilerplate

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [X] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
- [X] double-check your branch is based on `dev` and targets `dev` 
- [X] Pull request has tests (we are going for 100% coverage!)
- [X] Code is well-commented, linted and follows project conventions
- [X] Documentation is updated (if necessary)
- [X] Internal code generators and templates are updated (if necessary)
- [X] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/react-boilerplate/react-boilerplate/blob/master/LICENSE.md).
