### PR TITLE
chore(templates): turn `App` into a functional component

### DIFF
--- a/internals/templates/containers/App/index.js
+++ b/internals/templates/containers/App/index.js
@@ -17,16 +17,13 @@ import { Switch, Route } from 'react-router-dom';
 import HomePage from 'containers/HomePage/Loadable';
 import NotFoundPage from 'containers/NotFoundPage/Loadable';
 
-export default class App extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
-
-  render() {
-    return (
-      <div>
-        <Switch>
-          <Route exact path="/" component={HomePage} />
-          <Route component={NotFoundPage} />
-        </Switch>
-      </div>
-    );
-  }
+export default function App() {
+  return (
+    <div>
+      <Switch>
+        <Route exact path="/" component={HomePage} />
+        <Route component={NotFoundPage} />
+      </Switch>
+    </div>
+  );
 }


### PR DESCRIPTION
Fixes #1884

Turned `App` into a functional component to be consistent with `App` in the example application also I don't think extending it from `PureComponent` provides any benefits over a regular component or function in this case.