### PR TITLE
Fix loaders omission of '-loader' suffix in SASS docs

### DIFF
--- a/docs/css/sass.md
+++ b/docs/css/sass.md
@@ -14,7 +14,7 @@ to the loaders section in `internals/webpack/webpack.base.babel.js` so it reads 
    {
       test: /\.scss$/,
       exclude: /node_modules/,
-      loaders: ['style', 'css', 'sass']
+      loaders: ['style-loader', 'css-loader', 'sass-loader']
     }
     ```
 


### PR DESCRIPTION
This is a solution to [issue #1932](https://github.com/react-boilerplate/react-boilerplate/issues/1932).