### PR TITLE
feat(core): Set Referrer Policy to "origin" using document meta tag

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,6 +3,9 @@
   <head>
     <!-- The first thing in any HTML file should be the charset -->
     <meta charset="utf-8">
+    
+    <!-- Send only the base url to third party servers -->
+    <meta name=“referrer” content=“origin”>
 
     <!-- Make the page mobile compatible -->
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Add `<meta name=“referrer” content=“origin”>` to make the application more secure by not sending the full url to servers other than the origin.