### PR TITLE
fix(internals): Update `image-webpack-loader` query

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -51,10 +51,16 @@ module.exports = (options) => ({
           'file-loader',
           {
             loader: 'image-webpack-loader',
-            options: {
-              progressive: true,
-              optimizationLevel: 7,
-              interlaced: false,
+            query: {
+              mozjpeg: {
+                progressive: true,
+              },
+              gifsicle: {
+                interlaced: false,
+              },
+              optipng: {
+                optimizationLevel: 7,
+              },
               pngquant: {
                 quality: '65-90',
                 speed: 4,


### PR DESCRIPTION
This PR fixes the following warning which come as a result of using images in the components:
```
./app/assets/images/image.png
(Emitted value instead of an instance of Error) DEPRECATED. Configure gifsicle's interlaced option in its own options. (gifsicle.interlaced)
 @ ./app/containers/HomePage/index.js 24:0-75
 @ ./app/containers/HomePage/Loadable.js
 @ ./app/containers/App/index.js
 @ ./app/app.js
 @ multi eventsource-polyfill webpack-hot-middleware/client?reload=true ./app/app.js
```

The solution was found in this SO thread: https://stackoverflow.com/questions/42206190/webpack-2-warning-in-png-svg-deprecated-configure-optipngs-optimizatio.