### PR TITLE
chore(internals): Upgrade enzyme to v3

### DIFF
--- a/app/components/Header/tests/A.test.js
+++ b/app/components/Header/tests/A.test.js
@@ -6,7 +6,7 @@ import A from '../A';
 describe('<A />', () => {
   it('should render an <a> tag', () => {
     const renderedComponent = render(<A />);
-    expect(renderedComponent.find('a').length).toEqual(1);
+    expect(renderedComponent.is('a')).toEqual(true);
   });
 
   it('should have a className attribute', () => {

--- a/app/components/Header/tests/Img.test.js
+++ b/app/components/Header/tests/Img.test.js
@@ -6,7 +6,7 @@ import Img from '../Img';
 describe('<Img />', () => {
   it('should render an <img> tag', () => {
     const renderedComponent = render(<Img src={'http://example.com/test.jpg'} alt={'test'} />);
-    expect(renderedComponent.find('img').length).toEqual(1);
+    expect(renderedComponent.is('img')).toEqual(true);
   });
 
   it('should have a className attribute', () => {

--- a/app/components/LoadingIndicator/tests/index.test.js
+++ b/app/components/LoadingIndicator/tests/index.test.js
@@ -4,10 +4,11 @@ import { render } from 'enzyme';
 import LoadingIndicator from '../index';
 
 describe('<LoadingIndicator />', () => {
-  it('should render 13 divs', () => {
+  it('should render 12 child divs', () => {
     const renderedComponent = render(
       <LoadingIndicator />
     );
-    expect(renderedComponent.find('div').length).toBe(13);
+    // find all child divs
+    expect(renderedComponent.find('div').length).toBe(12);
   });
 });

--- a/app/containers/RepoListItem/tests/IssueIcon.test.js
+++ b/app/containers/RepoListItem/tests/IssueIcon.test.js
@@ -6,7 +6,7 @@ import IssueIcon from '../IssueIcon';
 describe('<IssueIcon />', () => {
   it('should render an <svg> tag', () => {
     const renderedComponent = render(<IssueIcon />);
-    expect(renderedComponent.find('svg').length).toEqual(1);
+    expect(renderedComponent.is('svg')).toEqual(true);
   });
 
   it('should have a className attribute', () => {

--- a/app/containers/RepoListItem/tests/IssueLink.test.js
+++ b/app/containers/RepoListItem/tests/IssueLink.test.js
@@ -6,7 +6,7 @@ import IssueLink from '../IssueLink';
 describe('<IssueLink />', () => {
   it('should render an <a> tag', () => {
     const renderedComponent = render(<IssueLink />);
-    expect(renderedComponent.find('a').length).toEqual(1);
+    expect(renderedComponent.is('a')).toEqual(true);
   });
 
   it('should have a className attribute', () => {

--- a/app/containers/RepoListItem/tests/RepoLink.test.js
+++ b/app/containers/RepoListItem/tests/RepoLink.test.js
@@ -6,7 +6,7 @@ import RepoLink from '../RepoLink';
 describe('<RepoLink />', () => {
   it('should render an <a> tag', () => {
     const renderedComponent = render(<RepoLink />);
-    expect(renderedComponent.find('a').length).toEqual(1);
+    expect(renderedComponent.is('a')).toEqual(true);
   });
 
   it('should have a className attribute', () => {

--- a/internals/testing/enzyme-setup.js
+++ b/internals/testing/enzyme-setup.js
@@ -1,0 +1,4 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+
+configure({ adapter: new Adapter() });

--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
       ".*\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/internals/mocks/image.js"
     },
     "setupTestFrameworkScriptFile": "<rootDir>/internals/testing/test-bundler.js",
+    "setupFiles": ["<rootDir>/internals/testing/enzyme-setup.js"],
     "testRegex": "tests/.*\\.test\\.js$"
   },
   "dependencies": {
@@ -264,7 +265,8 @@
     "circular-dependency-plugin": "3.0.0",
     "coveralls": "2.13.1",
     "css-loader": "0.28.4",
-    "enzyme": "2.8.2",
+    "enzyme": "3.1.0",
+    "enzyme-adapter-react-15": "1.0.1",
     "eslint": "3.19.0",
     "eslint-config-airbnb": "15.0.1",
     "eslint-config-airbnb-base": "11.2.0",


### PR DESCRIPTION
Upgrade to Enzyme 3

This resolves what I believe to be the major blocker for React 16
- [x] Upgrades enzyme to 3.1.0 and the required enzyme adapter (React 15 for now)
- [x] Adapter setup for tests
- [x] Resolves some syntax issues for some tests
- [x] Deal with different `find` behaviour for new static renderer

Resolves #1950