### PR TITLE
fix: quotes in referrer policy

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     
     <!-- Send only the base url to third party servers -->
-    <meta name=“referrer” content=“origin”>
+    <meta name="referrer" content="origin">
 
     <!-- Make the page mobile compatible -->
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Use the right quotes for the referrer policy.

Sorry for this very weird fault. 