### PR TITLE
fix(docs): Update `route` prop description for Button component

### DIFF
--- a/app/components/Button/index.js
+++ b/app/components/Button/index.js
@@ -2,8 +2,8 @@
  *
  * Button.js
  *
- * A common button, if you pass it a prop "route" it'll render a link to a react-router route
- * otherwise it'll render a link with an onclick
+ * A common button. If you pass it the prop "handleRoute" it'll render a link to a react-router route.
+ * Otherwise it'll render a link with an onclick.
  */
 
 import React, { Children } from 'react';


### PR DESCRIPTION
*In: app/components/Button/index.js*

Prop **route** was changed to **handleRoute** in Jan 19, 2016, but the commented instructions were not updated.