### PR TITLE
add missing semicolon in clean.js which is ignored file for eslint checks

### DIFF
--- a/internals/scripts/clean.js
+++ b/internals/scripts/clean.js
@@ -28,12 +28,12 @@ shell.mv('internals/templates/containers', 'app');
 shell.mv('internals/templates/tests', 'app');
 
 // Handle translations/
-shell.rm('-rf', 'app/translations')
+shell.rm('-rf', 'app/translations');
 shell.mv('internals/templates/translations', 'app');
 
 // Handle utils/
 shell.rm('-rf', 'app/utils');
-shell.mv('internals/templates/utils', 'app')
+shell.mv('internals/templates/utils', 'app');
 
 // Replace the files in the root app/ folder
 shell.cp('internals/templates/app.js', 'app/app.js');


### PR DESCRIPTION
When I opened clean.js file I saw some eslint errors for semicolons. It seems clean.js is ignored from eslint check (--ignore-pattern internals/scripts)
