### PR TITLE
fix(internals): Fix extract-intl incorrect variable declaring

### DIFF
--- a/internals/scripts/extract-intl.js
+++ b/internals/scripts/extract-intl.js
@@ -131,8 +131,9 @@ const extractFromFile = async (fileName) => {
   for (const locale of locales) {
     const translationFileName = `app/translations/${locale}.json`;
 
+    let localeTaskDone;
     try {
-      const localeTaskDone = task(
+      localeTaskDone = task(
         `Writing translation messages for ${locale} to: ${translationFileName}`
       );
 


### PR DESCRIPTION
One method in file uses wrong declaration for one variable. 

f.e. uses next way:
```
try {
  const localeTaskDone = () => (error) => {}

  localeTaskDone();
}
catch(e ){
  localeTaskDone(e);
}
```

It's quite evident that `localeTaskDone` is not available in catch block, because it is declared in try block.