### PR TITLE
Update nginx.conf

### DIFF
--- a/app/.nginx.conf
+++ b/app/.nginx.conf
@@ -79,15 +79,15 @@ server {
     # Set path
     root /var/www/;
     try_files $uri /index.html;
-  }
 
 # Do not cache sw.js, required for offline-first updates.
-  location /sw.js {
+    location /sw.js {
       add_header Cache-Control "no-cache";
       proxy_cache_bypass $http_pragma;
       proxy_cache_revalidate on;
       expires off;
       access_log off;
+    }
   }
 
 ##


### PR DESCRIPTION
# Problem

Nginx configuration responds with 404 when requesting `/sw.js` since the `location /sw.js` does not serve the file.

# Solution

Nest `location /sw.js` in `location /` block.

Quote from @gihrig in #1381 

> I have not tested these configurations

Evidently, from the indentation of the `location /sw.js` block, it was intended to be nested in a location block that serves `sw.js`.

Closes #1844

Closes #1687