### PR TITLE
Use the url-loader to inline small images

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -48,7 +48,12 @@ module.exports = (options) => ({
       {
         test: /\.(jpg|png|gif)$/,
         use: [
-          'file-loader',
+          {
+            loader: 'url-loader',
+            options: {
+              limit: 10000,
+            },
+          },
           {
             loader: 'image-webpack-loader',
             query: {


### PR DESCRIPTION
With this PR, webpack will inline small images (smaller than 10,000 bytes) instead of emitting them as separate files. This would save an extra request (pretty important for HTTP/1 and might have a small effect for HTTP/2).

The `url-loader` is also already enabled for video files: https://github.com/react-boilerplate/react-boilerplate/blob/e39f8bdca29a35edbd7480968c9fe0b2c9438860/internals/webpack/webpack.base.babel.js#L74-L82