### PR TITLE
fix(.nginx.conf) moving root path to the main server block

### DIFF
--- a/app/.nginx.conf
+++ b/app/.nginx.conf
@@ -73,11 +73,11 @@ server {
 # To let nginx use its own DNS Resolver
 # resolver <IP DNS resolver>;
 
+# Set path
+  root /var/www/;
 
 # Always serve index.html for any request
   location / {
-    # Set path
-    root /var/www/;
     try_files $uri /index.html;
   }
 


### PR DESCRIPTION
With the addition of the 'Do not cache sw.js' block, the root path, that is in the 'Always serve index.html' block, should move to the main server block or the sw.js will not be found.