### PR TITLE
Add basic jsconfig.json

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "baseUrl": "app",
+    "module": "commonjs",
+    "target": "es2016",
+    "jsx": "react"
+  },
+  "exclude": [
+    "node_modules",
+    "**/node_modules/*"
+  ]
+}


### PR DESCRIPTION
Fixes #2073

Adds a simple jsconfig to improve editor support. See #2073 for details on why a `jsconfig` is beneficial
