### PR TITLE
Fix name parameter jsdoc type

### DIFF
--- a/app/containers/HomePage/actions.js
+++ b/app/containers/HomePage/actions.js
@@ -22,7 +22,7 @@ import {
 /**
  * Changes the input field of the form
  *
- * @param  {name} name The new text of the input field
+ * @param {string} name The new text of the input field
  *
  * @return {object}    An action object with a type of CHANGE_USERNAME
  */


### PR DESCRIPTION
Small fix for jsdoc type of `name`, which should be type `string` instead of type `name`
