### PR TITLE
 feat(core): Add babel-plugin-transform-react-jsx-source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 
 node_js:
+  - 8
   - 7
   - 6
-  - 5
 
 script:
   - node ./internals/scripts/generate-templates-for-linting

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ environment:
 
   matrix:
     # Node versions to run
+    - nodejs_version: 8
     - nodejs_version: 7
     - nodejs_version: 6
-    - nodejs_version: 5
 
 # Fix line endings in Windows. (runs before repo cloning)
 init:

--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -157,7 +157,7 @@ pipelines:
 ## I'm using Node v0.12 and the server doesn't work?
 
 We settled on supporting the last three major Node.js versions for the boilerplate – at the moment
-of this writing those are v5, v6 and v7. We **highly recommend upgrading to a newer Node.js version**!
+of this writing those are v6, v7 and v8. We **highly recommend upgrading to a newer Node.js version**!
 
 If you _have_ to use Node.js 0.12, you can hack around the server not running by using `babel-cli` to
 run the server: `npm install babel-cli`, and then replace all instances of `node server` in the `"scripts"`

--- a/internals/scripts/extract-intl.js
+++ b/internals/scripts/extract-intl.js
@@ -15,7 +15,7 @@ const presets = pkg.babel.presets;
 const plugins = pkg.babel.plugins || [];
 
 const i18n = require('../../app/i18n');
-import { DEFAULT_LOCALE } from '../../app/containers/App/constants';
+const { DEFAULT_LOCALE } = require('../../app/containers/App/constants');
 
 require('shelljs/global');
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "url": "git://github.com/react-boilerplate/react-boilerplate.git"
   },
   "engines": {
-    "npm": ">=3",
-    "node": ">=5"
+    "npm": ">=5",
+    "node": ">=6"
   },
   "author": "Max Stoiber",
   "license": "MIT",
@@ -69,7 +69,8 @@
     "env": {
       "development": {
         "only": [
-          "app"
+          "app",
+          "internals/scripts"
         ],
         "plugins": [
           "transform-react-jsx-source"

--- a/package.json
+++ b/package.json
@@ -67,6 +67,14 @@
       "stage-0"
     ],
     "env": {
+      "development": {
+        "only": [
+          "app"
+        ],
+        "plugins": [
+          "transform-react-jsx-source"
+        ]
+      },
       "production": {
         "only": [
           "app"

--- a/package.json
+++ b/package.json
@@ -275,6 +275,7 @@
     "babel-plugin-transform-react-constant-elements": "6.23.0",
     "babel-plugin-transform-react-inline-elements": "6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
+    "babel-plugin-transform-react-jsx-source": "6.22.0",
     "babel-preset-env": "1.5.1",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,7 +1000,7 @@ babel-plugin-transform-react-jsx-self@^6.22.0:
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-react-jsx-source@^6.22.0:
+babel-plugin-transform-react-jsx-source@6.22.0, babel-plugin-transform-react-jsx-source@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz#66ac12153f5cd2d17b3c19268f4bf0197f44ecd6"
   dependencies:


### PR DESCRIPTION
Add `babel-plugin-transform-react-jsx-source` to `dev`, which has been done by @justingreenberg but not in `dev`, see comment [here](https://github.com/react-boilerplate/react-boilerplate/pull/1969#issuecomment-339693446). [Here](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html#component-stack-traces) is why we need this plugin.

- [x] Add `babel-plugin-transform-react-jsx-source`.
- [x] Update engines[node >= 6, npm >= 5] in package.json.
- [x] Remove node v5 support from appveyor/travis.
- [x] Add 'internals/scripts' to the babel `development` env, because `internals/scripts` also needs `babel` at compile time.
