### PR TITLE
Fix quickstart instruction for showing HMR in action

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,8 @@
     - Add a Github username to see Redux and Redux Sagas in action: effortless
       async state updates and side effects are now yours :)
     - Edit the file at `./app/components/Header/index.js` so that the text of
-      the `<Button>` component reads "Features!!!"... [Hot Module Reloading](https://webpack.js.org/guides/hot-module-replacement/) gives
+      the `<HeaderLink>` component to `/features` reads "Features!!!" (just remove the entire FormattedMessage element)
+      ... [Hot Module Reloading](https://webpack.js.org/guides/hot-module-replacement/) gives
       you a feedback loop with your UI so smooth it's almost conversational!
     - Click your (newly emphatic) Features button to see React Router in action...
       Now you can share a direct link to that content privately over your LAN or


### PR DESCRIPTION
This fixes #1741. For me at least, this worked to get through the quickstart (changing the `messages.features` inside `message.js` didn't work).

Regarding linting, I don't know how the markdown needs to be wrapped, but this made sense for me.