### PR TITLE
Import prop types in component class and stateless generators

### DIFF
--- a/internals/generators/component/class.js.hbs
+++ b/internals/generators/component/class.js.hbs
@@ -5,6 +5,7 @@
 */
 
 import React from 'react';
+// import PropTypes from 'prop-types';
 // import styled from 'styled-components';
 
 {{#if wantMessages}}

--- a/internals/generators/component/stateless.js.hbs
+++ b/internals/generators/component/stateless.js.hbs
@@ -5,6 +5,7 @@
 */
 
 import React from 'react';
+// import PropTypes from 'prop-types';
 // import styled from 'styled-components';
 
 {{#if wantMessages}}


### PR DESCRIPTION
Currently using the component  generators creates the propTypes object on a component, but **does not** import PropTypes resulting in  ```Uncaught ReferenceError: PropTypes is not defined``` if you forget to add the import. Seems like if the generator does one it should also do the other.

I added ```//import PropTypes from 'prop-types';``` to the class and stateless component generators as a fix, commented out so it doesn't blow up es-lint with `'PropTypes' is defined but never used  no-unused-vars` errors