### PR TITLE
Allow to pass additional parameters to the injected sagas

### DIFF
--- a/app/utils/injectSaga.js
+++ b/app/utils/injectSaga.js
@@ -13,9 +13,13 @@ import getInjectors from './sagaInjectors';
  * cancelled with `task.cancel()` on component un-mount for improved performance. Another two options:
  *   - constants.DAEMON—starts the saga on component mount and never cancels it or starts again,
  *   - constants.ONCE_TILL_UNMOUNT—behaves like 'RESTART_ON_REMOUNT' but never runs it again.
- *
+ * @param {array} [args] Arguments passed to the saga once called
+ * By default your saga will receive
+ *   - component props
+ *   - action
+ * If defined, the saga will receive those args instead of the component props
  */
-export default ({ key, saga, mode }) => (WrappedComponent) => {
+export default ({ key, saga, mode, args }) => (WrappedComponent) => {
   class InjectSaga extends React.Component {
     static WrappedComponent = WrappedComponent;
     static contextTypes = {
@@ -25,8 +29,9 @@ export default ({ key, saga, mode }) => (WrappedComponent) => {
 
     componentWillMount() {
       const { injectSaga } = this.injectors;
+      const injectedArgs = args || [this.props];
 
-      injectSaga(key, { saga, mode }, this.props);
+      injectSaga(key, { saga, mode }, ...injectedArgs);
     }
 
     componentWillUnmount() {

--- a/app/utils/sagaInjectors.js
+++ b/app/utils/sagaInjectors.js
@@ -30,7 +30,7 @@ const checkDescriptor = (descriptor) => {
 };
 
 export function injectSagaFactory(store, isValid) {
-  return function injectSaga(key, descriptor = {}, args) {
+  return function injectSaga(key, descriptor = {}, ...args) {
     if (!isValid) checkStore(store);
 
     const newDescriptor = { ...descriptor, mode: descriptor.mode || RESTART_ON_REMOUNT };
@@ -51,7 +51,7 @@ export function injectSagaFactory(store, isValid) {
     }
 
     if (!hasSaga || (hasSaga && mode !== DAEMON && mode !== ONCE_TILL_UNMOUNT)) {
-      store.injectedSagas[key] = { ...newDescriptor, task: store.runSaga(saga, args) }; // eslint-disable-line no-param-reassign
+      store.injectedSagas[key] = { ...newDescriptor, task: store.runSaga(saga, ...args) }; // eslint-disable-line no-param-reassign
     }
   };
 }

--- a/app/utils/tests/injectSaga.test.js
+++ b/app/utils/tests/injectSaga.test.js
@@ -45,6 +45,16 @@ describe('injectSaga decorator', () => {
     expect(injectors.injectSaga).toHaveBeenCalledWith('test', { saga: testSaga, mode: 'testMode' }, props);
   });
 
+  it('should inject given saga, mode, and user defined args', () => {
+    const props = { testProp: 'test' };
+    const args = { argument: 'test' };
+    ComponentWithSaga = injectSaga({ key: 'test', saga: testSaga, mode: 'testMode', args: [args] })(Component);
+    shallow(<ComponentWithSaga {...props} />, { context: { store } });
+
+    expect(injectors.injectSaga).toHaveBeenCalledTimes(1);
+    expect(injectors.injectSaga).toHaveBeenCalledWith('test', { saga: testSaga, mode: 'testMode' }, args);
+  });
+
   it('should eject on unmount with a correct saga key', () => {
     const props = { test: 'test' };
     const renderedComponent = shallow(<ComponentWithSaga {...props} />, { context: { store } });

--- a/app/utils/tests/sagaInjectors.test.js
+++ b/app/utils/tests/sagaInjectors.test.js
@@ -195,7 +195,7 @@ describe('injectors', () => {
       injectSaga('test', { saga: testSaga1 });
 
       expect(cancel).toHaveBeenCalledTimes(1);
-      expect(store.runSaga).toHaveBeenCalledWith(testSaga1, undefined);
+      expect(store.runSaga).toHaveBeenCalledWith(testSaga1);
     });
 
     it('should not cancel saga if different implementation in production', () => {

--- a/internals/templates/utils/injectSaga.js
+++ b/internals/templates/utils/injectSaga.js
@@ -13,9 +13,13 @@ import getInjectors from './sagaInjectors';
  * cancelled with `task.cancel()` on component un-mount for improved performance. Another two options:
  *   - constants.DAEMON—starts the saga on component mount and never cancels it or starts again,
  *   - constants.ONCE_TILL_UNMOUNT—behaves like 'RESTART_ON_REMOUNT' but never runs it again.
- *
+ * @param {array} [args] Arguments passed to the saga once called
+ * By default your saga will receive
+ *   - component props
+ *   - action
+ * If defined, the saga will receive those args instead of the component props
  */
-export default ({ key, saga, mode }) => (WrappedComponent) => {
+export default ({ key, saga, mode, args }) => (WrappedComponent) => {
   class InjectSaga extends React.Component {
     static WrappedComponent = WrappedComponent;
     static contextTypes = {
@@ -25,8 +29,9 @@ export default ({ key, saga, mode }) => (WrappedComponent) => {
 
     componentWillMount() {
       const { injectSaga } = this.injectors;
+      const injectedArgs = args || [this.props];
 
-      injectSaga(key, { saga, mode }, this.props);
+      injectSaga(key, { saga, mode }, ...injectedArgs);
     }
 
     componentWillUnmount() {

--- a/internals/templates/utils/sagaInjectors.js
+++ b/internals/templates/utils/sagaInjectors.js
@@ -30,7 +30,7 @@ const checkDescriptor = (descriptor) => {
 };
 
 export function injectSagaFactory(store, isValid) {
-  return function injectSaga(key, descriptor = {}, args) {
+  return function injectSaga(key, descriptor = {}, ...args) {
     if (!isValid) checkStore(store);
 
     const newDescriptor = { ...descriptor, mode: descriptor.mode || RESTART_ON_REMOUNT };
@@ -51,7 +51,7 @@ export function injectSagaFactory(store, isValid) {
     }
 
     if (!hasSaga || (hasSaga && mode !== DAEMON && mode !== ONCE_TILL_UNMOUNT)) {
-      store.injectedSagas[key] = { ...newDescriptor, task: store.runSaga(saga, args) }; // eslint-disable-line no-param-reassign
+      store.injectedSagas[key] = { ...newDescriptor, task: store.runSaga(saga, ...args) }; // eslint-disable-line no-param-reassign
     }
   };
 }

--- a/internals/templates/utils/tests/injectSaga.test.js
+++ b/internals/templates/utils/tests/injectSaga.test.js
@@ -45,6 +45,16 @@ describe('injectSaga decorator', () => {
     expect(injectors.injectSaga).toHaveBeenCalledWith('test', { saga: testSaga, mode: 'testMode' }, props);
   });
 
+  it('should inject given saga, mode, and user defined args', () => {
+    const props = { testProp: 'test' };
+    const args = { argument: 'test' };
+    ComponentWithSaga = injectSaga({ key: 'test', saga: testSaga, mode: 'testMode', args: [args] })(Component);
+    shallow(<ComponentWithSaga {...props} />, { context: { store } });
+
+    expect(injectors.injectSaga).toHaveBeenCalledTimes(1);
+    expect(injectors.injectSaga).toHaveBeenCalledWith('test', { saga: testSaga, mode: 'testMode' }, args);
+  });
+
   it('should eject on unmount with a correct saga key', () => {
     const props = { test: 'test' };
     const renderedComponent = shallow(<ComponentWithSaga {...props} />, { context: { store } });

--- a/internals/templates/utils/tests/sagaInjectors.test.js
+++ b/internals/templates/utils/tests/sagaInjectors.test.js
@@ -195,7 +195,7 @@ describe('injectors', () => {
       injectSaga('test', { saga: testSaga1 });
 
       expect(cancel).toHaveBeenCalledTimes(1);
-      expect(store.runSaga).toHaveBeenCalledWith(testSaga1, undefined);
+      expect(store.runSaga).toHaveBeenCalledWith(testSaga1);
     });
 
     it('should not cancel saga if different implementation in production', () => {


### PR DESCRIPTION
This PR needs some additional tests, but I wanted to have your feedback first.

In RBP 3.4 you would create your sagas as

```js
function* mySaga(action) {
   console.log(action); // { type: 'MY_ACTION' }
}
```

In 3.5 instead if you're using the `injectSaga` you end up with

```js
function* mySaga(whatsThis) {
   console.log(whatsThis); // it's the whole props object
   // turns out that the action is now the second parameter
}
```

As I'm updating my code, I really don't fancy modifying all my sagas to add an extra argument.

Moreover, I don't really like using props inside my saga, feels brittle. I thought the whole point of using actions was to pass parameters to a saga that doesn't have to depend on the props.

Finally, in another project based on 3.4 I need to access a firebase instance (irrelevant) and I want to have some sort of indirection. So instead of `import` the instance I need, I pass it as an argument to `injectSaga` inside `routes.js`. This option is now gone, there's no way to pass anything to the saga.

Getting to the point, I think it's handy to be able to pass stuff down the saga.

The proposed implementation works like this

```js
injectSaga({ key: 's1', saga: saga1 }); // same as the current dev branch
injectSaga({ key: 's2', saga: saga2, args: [] });
injectSaga({ key: 's3', saga: saga3, args: [{ banana: ' yellow'}] });

function* saga1 (props, action) {}
function* saga2 (action) {}
function* saga3 (fruit, action) {}
```

What do you guys think?

I don't like too much that there's no way to have `fruit` and `props` at the same time, so maybe there should be a flag to turn `props` on or off?

```js
injectSaga({ key: 'flag1', saga: saga1 }); // same as the current dev branch
injectSaga({ key: 'flag2', saga: saga2, props: false });
injectSaga({ key: 'flag3', saga: saga3, args: [{ banana: ' yellow'}], props: false });
injectSaga({ key: 'flag4', saga: saga4, args: [{ banana: ' yellow'}] });

function* saga1 (props, action) {}
function* saga2 (action) {}
function* saga3 (fruit, action) {}
function* saga4 (fruit, props, action) {}
```

For what it's worth, I don't think I'll ever use `props` in my saga