### PR TITLE
Adds eslint --fix flag ( to auto-apply eslint fixers )

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "clean:all": "npm run analyze:clean && npm run test:clean && npm run build:clean",
     "generate": "plop --plopfile internals/generators/index.js",
     "lint": "npm run lint:js && npm run lint:css",
-    "lint:eslint": "eslint --ignore-path .gitignore --ignore-pattern internals/scripts",
+    "lint:eslint": "eslint --ignore-path .gitignore --ignore-pattern internals/scripts --fix",
     "lint:js": "npm run lint:eslint -- . ",
     "lint:css": "stylelint \"./app/**/*.js\"",
     "lint:staged": "lint-staged",


### PR DESCRIPTION
Closes #2111 

This adds `--fix` flag in the `lint:eslint` script in `package.json`. Allows to try to run eslint fixers before showing line errors to users.