### PR TITLE
Add "Setting  up your editor" docs section

### DIFF
--- a/docs/general/README.md
+++ b/docs/general/README.md
@@ -10,6 +10,7 @@ ideas on what represents optimal developer experience, best practice, most
 efficient tooling and cleanest project structure.
 
 - [**CLI Commands**](commands.md)
+- [Setting up your editor](editor.md)
 - [Tool Configuration](files.md)
 - [Server Configurations](server-configs.md)
 - [Deployment](deployment.md) *(currently Heroku specific)*

--- a/docs/general/editor.md
+++ b/docs/general/editor.md
@@ -1,0 +1,23 @@
+# Setting Up Your Editor
+
+You can edit React Boilerplate using any editor or IDE, but there are a few extra steps that you can take to make sure your coding experience is as good as it can be.
+
+## VS Code 
+To get the best editing experience with [VS Code](https://code.visualstudio.com), create a [`jsconfig.json`](https://code.visualstudio.com/Docs/languages/javascript#_javascript-project-jsconfigjson) file at the root of your project:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": "app",
+    "module": "commonjs",
+    "target": "es2016",
+    "jsx": "react"
+  },
+  "exclude": [
+    "node_modules",
+    "**/node_modules/*"
+  ]
+}
+```
+
+This `jsconfig.json` file tells VS Code to treat all JS file as part of the same project, improving IntelliSense, code navigation, and refactoring. You can configure project wide settings in using the `jsconfig.json`, such as only allowing functions from the ES5 standard library, or even enable [more advanced type checking for JS files](https://code.visualstudio.com/docs/languages/javascript#_type-checking-and-quick-fixes-for-javascript-files)


### PR DESCRIPTION
Follow up on #2073

Adds a new docs page about setting up your editor. This page specifically documents creating a `jsconfig.json` to improve the editing experinace with VS Code, which was the focus of #2073