### PR TITLE
Test matrix update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
+  - 9
   - 8
-  - 7
   - 6
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 
 script:
   - node ./internals/scripts/generate-templates-for-linting
-  - npm run test
+  - npm test -- --maxWorkers=4
   - npm run build
 
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ environment:
 
   matrix:
     # Node versions to run
+    - nodejs_version: 9
     - nodejs_version: 8
-    - nodejs_version: 7
     - nodejs_version: 6
 
 # Fix line endings in Windows. (runs before repo cloning)


### PR DESCRIPTION
Updates test matrix to remove end of life node v7 and include the new stable version v9. 
Add maxWorkers argument to travis tests to [improve build time](https://facebook.github.io/jest/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server). 
