### PR TITLE
[Fix] Bad bundle filename generated on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -330,7 +330,7 @@
     "url-loader": "1.0.1",
     "webpack": "4.1.0",
     "webpack-cli": "2.0.10",
-    "webpack-dev-middleware": "3.0.0",
+    "webpack-dev-middleware": "3.0.1",
     "webpack-hot-middleware": "2.21.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10232,9 +10232,9 @@ webpack-cli@2.0.10:
     yeoman-environment "^2.0.0"
     yeoman-generator "github:ev1stensberg/generator#Feature-getArgument"
 
-webpack-dev-middleware@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.0.0.tgz#ae8902596f1b1fa8f7eada874aabb64cba9cd53e"
+webpack-dev-middleware@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.0.1.tgz#7ffd6d0192883c83d3f262e8d7dec822493c6166"
   dependencies:
     loud-rejection "^1.6.0"
     memory-fs "~0.4.1"


### PR DESCRIPTION
Upgrading the webpack-dev-middleware package that solves an issue with bad bundle filename generated on Windows.

See: https://github.com/webpack/webpack-dev-middleware/issues/270

This caused a blank screen and produced these errors:

```
manifest.json:1 Manifest: Line: 1, column: 1, Unexpected token.
reactBoilerplateDeps.dll.js:1 Uncaught SyntaxError: Unexpected token <
main.js:1 Uncaught SyntaxError: Unexpected token <
```