### PR TITLE
Updating order of module resolution in Webpack config

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -125,7 +125,10 @@ module.exports = (options) => ({
     }),
   ]),
   resolve: {
-    modules: ['app', 'node_modules'],
+    modules: [
+      'node_modules',
+      'app',
+    ],
     extensions: [
       '.js',
       '.jsx',


### PR DESCRIPTION
As encountered [here](https://github.com/ReactTraining/react-router/issues/6126), if someone uses and extends the boilerplate to create a singleton of say, `history` so it can be used in sagas/epics and so on, the module resolution order of apps -> node_modules means that react-router components like Redirect will import from the wrong instance of `history` (the local declaration in /app instead of the actual library in /node_modules).

Switching the order doesn't seem to cause any harm and means less chance of this affecting users.

Also splitting up the fields in the array onto multiple lines since it fits with all the other nearby arrays 😄 

## React Boilerplate

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
- [x] double-check your branch is based on `dev` and targets `dev` 
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/react-boilerplate/react-boilerplate/blob/master/LICENSE.md).
