### PR TITLE
add Lock app template

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,29 @@
+# Configuration for lock-threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 30
+
+# Issues and pull requests with these labels will not be locked. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs.
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30
+


### PR DESCRIPTION
I've added [Lock](https://probot.github.io/apps/lock/), a bot that locks closed issues that are a certain age old. I've set the number of days to be 30, because I constantly get notifications of people who are commenting on closed issues. Most of these comments / issues aren't an rbp-related issue, rather just asking for help. I want to curb convos on old, closed issues and then if/when someone opens a new issue, we can either solve the problem or direct them to StackOverflow. 

Let me know if this is overkill, but I think it just takes some of the weight off.