### PR TITLE
Fix the eslint-fix script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint": "npm run lint:js && npm run lint:css",
     "lint:css": "stylelint './app/**/*.js'",
     "lint:eslint": "eslint --ignore-path .gitignore --ignore-pattern internals/scripts",
-    "lint:eslint:fix": "eslint --ignore-path .gitignore --ignore-pattern internals/scripts --fix",
+    "lint:eslint:fix": "eslint app --fix",
     "lint:js": "npm run lint:eslint -- . ",
     "lint:staged": "lint-staged",
     "pretest": "npm run test:clean && npm run lint",


### PR DESCRIPTION
When running `lint:eslint:fix` nothing happens because we aren't invoking eslint like in all other scripts and resolving the root dir.

I reworked the script so it just covers `app/` and runs the `--fix` flag