### PR TITLE
Use .prettierrc path relative to .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
+const path = require("path");
 
-const prettierOptions = JSON.parse(fs.readFileSync('./.prettierrc', 'utf8'));
+const prettierOptions = JSON.parse(fs.readFileSync(path.resolve(__dirname, '.prettierrc'), 'utf8'));
 
 module.exports = {
   parser: 'babel-eslint',


### PR DESCRIPTION
The `path` argument of `fs.readFileSync` is relative to the working directory, so linting in Atom was broken for mono-repos (as eslint is not executed from the project root).