### PR TITLE
[Fix] Fixing issue where apple-touch-icon meta tags are pointing to n…

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -10,13 +10,6 @@
     <!-- Allow installing the app to the homescreen -->
     <meta name="mobile-web-app-capable" content="yes">
 
-    <!-- iOS home screen icons -->
-    <meta name="apple-mobile-web-app-title" content="react boilerplate">
-    <link rel="apple-touch-icon" sizes="120x120" href="/icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="/icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="167x167" href="/icon-167x167.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/icon-180x180.png">
-
     <link rel="icon" href="/favicon.ico" />
     <title>React.js Boilerplate</title>
   </head>

--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -75,6 +75,7 @@ module.exports = require('./webpack.base.babel')({
       description: 'My React Boilerplate-based project!',
       background_color: '#fafafa',
       theme_color: '#b1624d',
+      inject: true,
       ios: true,
       icons: [
         {

--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -75,10 +75,16 @@ module.exports = require('./webpack.base.babel')({
       description: 'My React Boilerplate-based project!',
       background_color: '#fafafa',
       theme_color: '#b1624d',
+      ios: true,
       icons: [
         {
           src: path.resolve('app/images/icon-512x512.png'),
-          sizes: [72, 96, 120, 128, 144, 152, 167, 180, 192, 384, 512],
+          sizes: [72, 96, 128, 144, 192, 384, 512],
+        },
+        {
+          src: path.resolve('app/images/icon-512x512.png'),
+          sizes: [120, 152, 167, 180],
+          ios: true,
         },
       ],
     }),


### PR DESCRIPTION
Icons are now generated by the "webpack-pwa-manifest" plugin. This however was not configured for generating the apple-touch-icon icons so the <link rel="apple-touch-icon" ... > in the index.html pointed to non existing sources.

Now the plugin adds:

```
<meta name="apple-mobile-web-app-title" content="React Boilerplate"/>
<meta name="apple-mobile-web-app-capable" content="yes"/>
<meta name="apple-mobile-web-app-status-bar-style" content="default"/>
<meta name="theme-color" content="#b1624d"/>
<link rel="apple-touch-icon" sizes="180x180" href="/icon_180x180.<hash>.png"/>
<link rel="apple-touch-icon" sizes="167x167" href="/icon_167x167.<hash>.png"/>
<link rel="apple-touch-icon" sizes="152x152" href="/icon_152x152.<hash>.png"/>
<link rel="apple-touch-icon" sizes="120x120" href="/icon_120x120.<hash>.png"/>
```