### PR TITLE
Poc react testing library

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
+const path = require("path");
 
-const prettierOptions = JSON.parse(fs.readFileSync('./.prettierrc', 'utf8'));
+const prettierOptions = JSON.parse(fs.readFileSync(path.resolve(__dirname, '.prettierrc'), 'utf8'));
 
 module.exports = {
   parser: 'babel-eslint',

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 # React Boilerplate
 
-Before opening a new issue, please take a moment to review our [**community guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/.github/CONTRIBUTING.md) to make the contribution process easy and effective for everyone involved.
+Before opening a new issue, please take a moment to review our [**community guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md) to make the contribution process easy and effective for everyone involved.
 
 Please direct redux-saga related questions to stack overflow:
 http://stackoverflow.com/questions/tagged/redux-saga
@@ -13,8 +13,8 @@ https://github.com/react-boilerplate/react-boilerplate/issues?q=is%3Aissue+is%3A
 
 ## Issue Type
 
-- [ ] Bug (https://github.com/react-boilerplate/react-boilerplate/blob/master/.github/CONTRIBUTING.md#bug-reports)
-- [ ] Feature (https://github.com/react-boilerplate/react-boilerplate/blob/master/.github/CONTRIBUTING.md#feature-requests)
+- [ ] Bug (https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md#bug-reports)
+- [ ] Feature (https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md#feature-requests)
 
 ## Description
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## React Boilerplate
 
-Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
+Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
 to make the process easy and effective for everyone involved.
 
 **Please open an issue** before embarking on any significant pull request, especially those that
@@ -9,7 +9,7 @@ on something that might not end up being merged into the project.
 
 Before opening a pull request, please ensure:
 
-- [ ] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
+- [ ] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
 - [ ] double-check your branch is based on `dev` and targets `dev` 
 - [ ] Pull request has tests (we are going for 100% coverage!)
 - [ ] Code is well-commented, linted and follows project conventions

--- a/app/components/A/tests/index.test.js
+++ b/app/components/A/tests/index.test.js
@@ -3,50 +3,49 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'react-testing-library';
 
 import A from '../index';
 
 const href = 'http://mxstbr.com/';
 const children = <h1>Test</h1>;
-const renderComponent = (props = {}) =>
-  shallow(
-    <A href={href} {...props}>
-      {children}
-    </A>,
-  );
+const renderComponent = (props = {}) => (
+  <A href={href} {...props}>
+    {children}
+  </A>
+);
 
 describe('<A />', () => {
   it('should render an <a> tag', () => {
-    const renderedComponent = renderComponent();
-    expect(renderedComponent.type()).toEqual('a');
+    const { container } = render(renderComponent());
+    expect(container.querySelector('a')).not.toBeNull();
   });
 
   it('should have an href attribute', () => {
-    const renderedComponent = renderComponent();
-    expect(renderedComponent.prop('href')).toEqual(href);
+    const { container } = render(renderComponent());
+    expect(container.querySelector('a').href).toEqual(href);
   });
 
   it('should have children', () => {
-    const renderedComponent = renderComponent();
-    expect(renderedComponent.contains(children)).toEqual(true);
+    const { container } = render(renderComponent());
+    expect(container.querySelector('a').children).toHaveLength(1);
   });
 
-  it('should have a className attribute', () => {
+  it('should have a class attribute', () => {
     const className = 'test';
-    const renderedComponent = renderComponent({ className });
-    expect(renderedComponent.find('a').hasClass(className)).toEqual(true);
+    const { container } = render(renderComponent({ className }));
+    expect(container.querySelector('a').classList).toContain(className);
   });
 
   it('should adopt a target attribute', () => {
     const target = '_blank';
-    const renderedComponent = renderComponent({ target });
-    expect(renderedComponent.prop('target')).toEqual(target);
+    const { container } = render(renderComponent({ target }));
+    expect(container.querySelector('a').target).toEqual(target);
   });
 
   it('should adopt a type attribute', () => {
     const type = 'text/html';
-    const renderedComponent = renderComponent({ type });
-    expect(renderedComponent.prop('type')).toEqual(type);
+    const { container } = render(renderComponent({ type }));
+    expect(container.querySelector('a').type).toEqual(type);
   });
 });

--- a/app/components/Button/tests/A.test.js
+++ b/app/components/Button/tests/A.test.js
@@ -1,27 +1,27 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'react-testing-library';
 
 import A from '../A';
 
 describe('<A />', () => {
   it('should render an <a> tag', () => {
-    const renderedComponent = shallow(<A />);
-    expect(renderedComponent.type()).toEqual('a');
+    const { container } = render(<A />);
+    expect(container.querySelector('a')).not.toBeNull();
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<A />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<A />);
+    expect(container.querySelector('a').hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<A id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<A id={id} />);
+    expect(container.querySelector('a').id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<A attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<A attribute="test" />);
+    expect(container.querySelector('a[attribute="test"]')).toBeNull();
   });
 });

--- a/app/components/Button/tests/StyledButton.test.js
+++ b/app/components/Button/tests/StyledButton.test.js
@@ -1,27 +1,27 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'react-testing-library';
 
 import StyledButton from '../StyledButton';
 
 describe('<StyledButton />', () => {
   it('should render an <button> tag', () => {
-    const renderedComponent = shallow(<StyledButton />);
-    expect(renderedComponent.type()).toEqual('button');
+    const { container } = render(<StyledButton />);
+    expect(container.querySelector('button')).not.toBeNull();
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<StyledButton />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<StyledButton />);
+    expect(container.querySelector('button').hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<StyledButton id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<StyledButton id={id} />);
+    expect(container.querySelector('button').id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<StyledButton attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<StyledButton attribute="test" />);
+    expect(container.querySelector('button[attribute="test"]')).toBeNull();
   });
 });

--- a/app/components/Button/tests/Wrapper.test.js
+++ b/app/components/Button/tests/Wrapper.test.js
@@ -1,27 +1,27 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
   it('should render an <div> tag', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.type()).toEqual('div');
+    const { container } = render(<Wrapper />);
+    expect(container.querySelector('div')).not.toBeNull();
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<Wrapper />);
+    expect(container.querySelector('div').hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<Wrapper id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<Wrapper id={id} />);
+    expect(container.querySelector('div').id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<Wrapper attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<Wrapper attribute="test" />);
+    expect(container.querySelector('div[attribute="test"]')).toBeNull();
   });
 });

--- a/app/components/Button/tests/index.test.js
+++ b/app/components/Button/tests/index.test.js
@@ -20,12 +20,12 @@ const renderComponent = (props = {}) =>
 describe('<Button />', () => {
   it('should render an <a> tag if no route is specified', () => {
     const renderedComponent = renderComponent({ href });
-    expect(renderedComponent.find('a').length).toEqual(1);
+    expect(renderedComponent.find('a')).toHaveLength(1);
   });
 
   it('should render a <button> tag to change route if the handleRoute prop is specified', () => {
     const renderedComponent = renderComponent({ handleRoute });
-    expect(renderedComponent.find('button').length).toEqual(1);
+    expect(renderedComponent.find('button')).toHaveLength(1);
   });
 
   it('should have children', () => {

--- a/app/components/Button/tests/index.test.js
+++ b/app/components/Button/tests/index.test.js
@@ -3,57 +3,58 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { cleanup, fireEvent, render } from 'react-testing-library';
 
 import Button from '../index';
 
 const handleRoute = () => {};
 const href = 'http://mxstbr.com';
 const children = <h1>Test</h1>;
-const renderComponent = (props = {}) =>
-  mount(
-    <Button href={href} {...props}>
-      {children}
-    </Button>,
-  );
+const renderComponent = (props = {}) => (
+  <Button href={href} {...props}>
+    {children}
+  </Button>
+);
 
 describe('<Button />', () => {
+  afterEach(cleanup);
+
   it('should render an <a> tag if no route is specified', () => {
-    const renderedComponent = renderComponent({ href });
-    expect(renderedComponent.find('a')).toHaveLength(1);
+    const { container } = render(renderComponent({ href }));
+    expect(container.querySelector('a')).not.toBeNull();
   });
 
   it('should render a <button> tag to change route if the handleRoute prop is specified', () => {
-    const renderedComponent = renderComponent({ handleRoute });
-    expect(renderedComponent.find('button')).toHaveLength(1);
+    const { container } = render(renderComponent({ handleRoute }));
+    expect(container.querySelector('button')).toBeDefined();
   });
 
   it('should have children', () => {
-    const renderedComponent = renderComponent();
-    expect(renderedComponent.contains(children)).toEqual(true);
+    const { container } = render(renderComponent());
+    expect(container.querySelector('a').children).toHaveLength(1);
   });
 
   it('should handle click events', () => {
     const onClickSpy = jest.fn();
-    const renderedComponent = renderComponent({ onClick: onClickSpy });
-    renderedComponent.find('a').simulate('click');
+    const { container } = render(renderComponent({ onClick: onClickSpy }));
+    fireEvent.click(container.querySelector('a'));
     expect(onClickSpy).toHaveBeenCalled();
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = renderComponent();
-    expect(renderedComponent.find('a').prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(renderComponent());
+    expect(container.querySelector('a').hasAttribute('class')).toBe(true);
   });
 
   it('should not adopt a type attribute when rendering an <a> tag', () => {
     const type = 'text/html';
-    const renderedComponent = renderComponent({ href, type });
-    expect(renderedComponent.find('a').prop('type')).toBeUndefined();
+    const { container } = render(renderComponent({ href, type }));
+    expect(container.querySelector(`a[type="${type}"]`)).toBeNull();
   });
 
   it('should not adopt a type attribute when rendering a button', () => {
     const type = 'submit';
-    const renderedComponent = renderComponent({ handleRoute, type });
-    expect(renderedComponent.find('button').prop('type')).toBeUndefined();
+    const { container } = render(renderComponent({ handleRoute, type }));
+    expect(container.querySelector('button').getAttribute('type')).toBeNull();
   });
 });

--- a/app/components/Footer/tests/Wrapper.test.js
+++ b/app/components/Footer/tests/Wrapper.test.js
@@ -1,27 +1,31 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
+  afterEach(cleanup);
+
   it('should render an <footer> tag', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.type()).toEqual('footer');
+    const { container } = render(<Wrapper />);
+    expect(container.querySelector('footer')).not.toBeNull();
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<Wrapper />);
+    expect(container.querySelector('footer').hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<Wrapper id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<Wrapper id={id} />);
+    expect(container.querySelector('footer').id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<Wrapper attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<Wrapper attribute="test" />);
+    expect(
+      container.querySelector('footer').getAttribute('attribute'),
+    ).toBeNull();
   });
 });

--- a/app/components/Footer/tests/__snapshots__/index.test.js.snap
+++ b/app/components/Footer/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Footer /> should render and match the snapshot 1`] = `
+<footer
+  className="Wrapper-ThVjl gDYfmS"
+>
+  <section>
+    <span>
+      This project is licensed under the MIT license.
+    </span>
+  </section>
+  <section>
+    <div
+      className="Wrapper-ThVjl eCtFPq"
+    >
+      <select
+        className="Select-eZBaHc btkmX"
+        onChange={[Function]}
+        value="en"
+      >
+        <option
+          value="en"
+        >
+          en
+        </option>
+        <option
+          value="de"
+        >
+          de
+        </option>
+      </select>
+    </div>
+  </section>
+  <section>
+    <span>
+      
+      Made with love by 
+      <a
+        className="A-bJefwH ePLwWG"
+        href="https://twitter.com/mxstbr"
+      >
+        Max Stoiber
+      </a>
+      .
+    
+    </span>
+  </section>
+</footer>
+`;

--- a/app/components/Footer/tests/index.test.js
+++ b/app/components/Footer/tests/index.test.js
@@ -1,36 +1,30 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { FormattedMessage } from 'react-intl';
+import renderer from 'react-test-renderer';
+import { IntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
+import { browserHistory } from 'react-router-dom';
 
-import A from 'components/A';
-import messages from '../messages';
 import Footer from '../index';
+import configureStore from '../../../configureStore';
 
 describe('<Footer />', () => {
-  it('should render the copyright notice', () => {
-    const renderedComponent = shallow(<Footer />);
-    expect(
-      renderedComponent.contains(
-        <section>
-          <FormattedMessage {...messages.licenseMessage} />
-        </section>,
-      ),
-    ).toBe(true);
+  let store;
+
+  beforeAll(() => {
+    store = configureStore({}, browserHistory);
   });
 
-  it('should render the credits', () => {
-    const renderedComponent = shallow(<Footer />);
-    expect(
-      renderedComponent.contains(
-        <section>
-          <FormattedMessage
-            {...messages.authorMessage}
-            values={{
-              author: <A href="https://twitter.com/mxstbr">Max Stoiber</A>,
-            }}
-          />
-        </section>,
-      ),
-    ).toBe(true);
+  it('should render and match the snapshot', () => {
+    const renderedComponent = renderer
+      .create(
+        <Provider store={store}>
+          <IntlProvider locale="en">
+            <Footer />
+          </IntlProvider>
+        </Provider>,
+      )
+      .toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
   });
 });

--- a/app/components/H1/tests/index.test.js
+++ b/app/components/H1/tests/index.test.js
@@ -1,18 +1,22 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import H1 from '../index';
 
 describe('<H1 />', () => {
+  afterAll(cleanup);
+
   it('should render a prop', () => {
     const id = 'testId';
-    const renderedComponent = shallow(<H1 id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<H1 id={id} />);
+    expect(container.querySelector('h1').id).toEqual(id);
   });
 
   it('should render its text', () => {
     const children = 'Text';
-    const renderedComponent = shallow(<H1>{children}</H1>);
-    expect(renderedComponent.contains(children)).toBe(true);
+    const { container, queryByText } = render(<H1>{children}</H1>);
+    const { childNodes } = container.querySelector('h1');
+    expect(childNodes).toHaveLength(1);
+    expect(queryByText(children)).not.toBeNull();
   });
 });

--- a/app/components/H2/tests/index.test.js
+++ b/app/components/H2/tests/index.test.js
@@ -1,18 +1,22 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import H2 from '../index';
 
 describe('<H2 />', () => {
+  afterAll(cleanup);
+
   it('should render a prop', () => {
     const id = 'testId';
-    const renderedComponent = shallow(<H2 id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<H2 id={id} />);
+    expect(container.querySelector('h2').id).toEqual(id);
   });
 
   it('should render its text', () => {
     const children = 'Text';
-    const renderedComponent = shallow(<H2>{children}</H2>);
-    expect(renderedComponent.contains(children)).toBe(true);
+    const { container, queryByText } = render(<H2>{children}</H2>);
+    const { childNodes } = container.querySelector('h2');
+    expect(childNodes).toHaveLength(1);
+    expect(queryByText(children)).not.toBeNull();
   });
 });

--- a/app/components/H3/tests/index.test.js
+++ b/app/components/H3/tests/index.test.js
@@ -1,18 +1,22 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import H3 from '../index';
 
 describe('<H3 />', () => {
+  afterAll(cleanup);
+
   it('should render a prop', () => {
     const id = 'testId';
-    const renderedComponent = shallow(<H3 id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<H3 id={id} />);
+    expect(container.querySelector('h3').id).toEqual(id);
   });
 
   it('should render its text', () => {
     const children = 'Text';
-    const renderedComponent = shallow(<H3>{children}</H3>);
-    expect(renderedComponent.contains(children)).toBe(true);
+    const { container, queryByText } = render(<H3>{children}</H3>);
+    const { childNodes } = container.querySelector('h3');
+    expect(childNodes).toHaveLength(1);
+    expect(queryByText(children)).not.toBeNull();
   });
 });

--- a/app/components/Header/tests/A.test.js
+++ b/app/components/Header/tests/A.test.js
@@ -1,29 +1,31 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import A from '../A';
 
 describe('<A />', () => {
+  afterEach(cleanup);
+
   it('should match the snapshot', () => {
     const renderedComponent = renderer.create(<A />).toJSON();
     expect(renderedComponent).toMatchSnapshot();
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = mount(<A />);
-    expect(renderedComponent.find('a').prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<A />);
+    expect(container.querySelector('a').hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = mount(<A id={id} />);
-    expect(renderedComponent.find('a').prop('id')).toEqual(id);
+    const { container } = render(<A id={id} />);
+    expect(container.querySelector('a').id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = mount(<A attribute="test" />);
-    expect(renderedComponent.find('a').prop('attribute')).toBeUndefined();
+    const { container } = render(<A attribute="test" />);
+    expect(container.querySelector('a').getAttribute('attribute')).toBeNull();
   });
 });

--- a/app/components/Header/tests/Img.test.js
+++ b/app/components/Header/tests/Img.test.js
@@ -1,11 +1,13 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import Img from '../Img';
 
 describe('<Img />', () => {
+  afterEach(cleanup);
+
   it('should match the snapshot', () => {
     const renderedComponent = renderer
       .create(<Img src="http://example.com/test.jpg" alt="test" />)
@@ -13,24 +15,24 @@ describe('<Img />', () => {
     expect(renderedComponent).toMatchSnapshot();
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = mount(
+  it('should have a class attribute', () => {
+    const { container } = render(
       <Img src="http://example.com/test.jpg" alt="test" />,
     );
-    expect(renderedComponent.find('img').prop('className')).toBeDefined();
+    expect(container.querySelector('img').hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
-    const renderedComponent = mount(
+    const { container } = render(
       <Img src="http://example.com/test.jpg" alt="test" />,
     );
-    expect(renderedComponent.find('img').prop('alt')).toEqual('test');
+    expect(container.querySelector('img').alt).toEqual('test');
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = mount(
+    const { container } = render(
       <Img src="http://example.com/test.jpg" attribute="test" alt="test" />,
     );
-    expect(renderedComponent.find('img').prop('attribute')).toBeUndefined();
+    expect(container.querySelector('img').getAttribute('attribute')).toBeNull();
   });
 });

--- a/app/components/Header/tests/__snapshots__/index.test.js.snap
+++ b/app/components/Header/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Header /> should render a div 1`] = `
+<div>
+  <a
+    class="A-bJefwH gmTDrD"
+    href="https://twitter.com/mxstbr"
+  >
+    <img
+      alt="react-boilerplate - Logo"
+      class="Img-funbTP warZo"
+      src="IMAGE_MOCK"
+    />
+  </a>
+  <div
+    class="NavBar-dbmxhD bluIjL"
+  >
+    <a
+      class="HeaderLink-icDyHV dNbVao"
+      href="/"
+    >
+      <span>
+        Home
+      </span>
+    </a>
+    <a
+      class="HeaderLink-icDyHV dNbVao"
+      href="/features"
+    >
+      <span>
+        Features
+      </span>
+    </a>
+  </div>
+</div>
+`;

--- a/app/components/Header/tests/index.test.js
+++ b/app/components/Header/tests/index.test.js
@@ -6,6 +6,6 @@ import Header from '../index';
 describe('<Header />', () => {
   it('should render a div', () => {
     const renderedComponent = shallow(<Header />);
-    expect(renderedComponent.find('div').length).toEqual(1);
+    expect(renderedComponent.find('div')).toHaveLength(1);
   });
 });

--- a/app/components/Header/tests/index.test.js
+++ b/app/components/Header/tests/index.test.js
@@ -1,11 +1,29 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
+import { Provider } from 'react-redux';
+import { IntlProvider } from 'react-intl';
+import { ConnectedRouter } from 'react-router-redux';
+import createHistory from 'history/createMemoryHistory';
 
 import Header from '../index';
+import configureStore from '../../../configureStore';
 
 describe('<Header />', () => {
+  const history = createHistory();
+  const store = configureStore({}, history);
+
+  afterEach(cleanup);
+
   it('should render a div', () => {
-    const renderedComponent = shallow(<Header />);
-    expect(renderedComponent.find('div')).toHaveLength(1);
+    const { container } = render(
+      <Provider store={store}>
+        <IntlProvider locale="en">
+          <ConnectedRouter history={history}>
+            <Header />
+          </ConnectedRouter>
+        </IntlProvider>
+      </Provider>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/app/components/Img/tests/index.test.js
+++ b/app/components/Img/tests/index.test.js
@@ -1,43 +1,51 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Img from '../index';
 
 const src = 'test.png';
 const alt = 'test';
 const renderComponent = (props = {}) =>
-  shallow(<Img src={src} alt={alt} {...props} />);
+  render(<Img src={src} alt={alt} {...props} />);
 
 describe('<Img />', () => {
+  afterEach(cleanup);
+
   it('should render an <img> tag', () => {
-    const renderedComponent = renderComponent();
-    expect(renderedComponent.is('img')).toBe(true);
+    const { container } = renderComponent();
+    const element = container.querySelector('img');
+    expect(element).not.toBeNull();
   });
 
   it('should have an src attribute', () => {
-    const renderedComponent = renderComponent();
-    expect(renderedComponent.prop('src')).toEqual(src);
+    const { container } = renderComponent();
+    const element = container.querySelector('img');
+    expect(element.hasAttribute('src')).toBe(true);
   });
 
   it('should have an alt attribute', () => {
-    const renderedComponent = renderComponent();
-    expect(renderedComponent.prop('alt')).toEqual(alt);
+    const { container } = renderComponent();
+    const element = container.querySelector('img');
+    expect(element.hasAttribute('alt')).toBe(true);
   });
 
-  it('should not have a className attribute', () => {
-    const renderedComponent = renderComponent();
-    expect(renderedComponent.prop('className')).toBeUndefined();
+  it('should not have a class attribute', () => {
+    const { container } = renderComponent();
+    const element = container.querySelector('img');
+    expect(element.hasAttribute('class')).toBe(false);
   });
 
   it('should adopt a className attribute', () => {
     const className = 'test';
-    const renderedComponent = renderComponent({ className });
-    expect(renderedComponent.hasClass(className)).toBe(true);
+    const { container } = renderComponent({ className });
+    const element = container.querySelector('img');
+    expect(element.className).toEqual(className);
   });
 
   it('should not adopt a srcset attribute', () => {
     const srcset = 'test-HD.png 2x';
-    const renderedComponent = renderComponent({ srcset });
-    expect(renderedComponent.prop('srcset')).toBeUndefined();
+    const { container } = renderComponent({ srcset });
+    const element = container.querySelector('img');
+    expect(element.hasAttribute('srcset')).toBe(false);
   });
 });

--- a/app/components/IssueIcon/index.js
+++ b/app/components/IssueIcon/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 function IssueIcon(props) {
   return (
-    <svg height="1em" width="0.875em" className={props.className}>
+    <svg height="1em" width="0.875em" className={props.className} {...props}>
       <path d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7S10.14 13.7 7 13.7 1.3 11.14 1.3 8s2.56-5.7 5.7-5.7m0-1.3C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7S10.86 1 7 1z m1 3H6v5h2V4z m0 6H6v2h2V10z" />
     </svg>
   );

--- a/app/components/IssueIcon/tests/index.test.js
+++ b/app/components/IssueIcon/tests/index.test.js
@@ -1,11 +1,13 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import IssueIcon from '../index';
 
 describe('<IssueIcon />', () => {
+  afterEach(cleanup);
+
   it('should render a SVG', () => {
-    const renderedComponent = shallow(<IssueIcon />);
-    expect(renderedComponent.find('svg')).toHaveLength(1);
+    const { container } = render(<IssueIcon />);
+    expect(container.querySelector('svg')).not.toBeNull();
   });
 });

--- a/app/components/IssueIcon/tests/index.test.js
+++ b/app/components/IssueIcon/tests/index.test.js
@@ -6,6 +6,6 @@ import IssueIcon from '../index';
 describe('<IssueIcon />', () => {
   it('should render a SVG', () => {
     const renderedComponent = shallow(<IssueIcon />);
-    expect(renderedComponent.find('svg').length).toBe(1);
+    expect(renderedComponent.find('svg')).toHaveLength(1);
   });
 });

--- a/app/components/List/tests/Ul.test.js
+++ b/app/components/List/tests/Ul.test.js
@@ -1,27 +1,33 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Ul from '../Ul';
 
 describe('<Ul />', () => {
+  afterEach(cleanup);
+
   it('should render an <ul> tag', () => {
-    const renderedComponent = shallow(<Ul />);
-    expect(renderedComponent.type()).toEqual('ul');
+    const { container } = render(<Ul />);
+    const element = container.firstElementChild;
+    expect(element.tagName).toEqual('UL');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<Ul />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<Ul />);
+    const element = container.firstElementChild;
+    expect(element.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<Ul id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<Ul id={id} />);
+    const element = container.firstElementChild;
+    expect(element.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<Ul attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<Ul attribute="test" />);
+    const element = container.firstElementChild;
+    expect(element.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/components/List/tests/Wrapper.test.js
+++ b/app/components/List/tests/Wrapper.test.js
@@ -1,27 +1,32 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
+  afterEach(cleanup);
+
   it('should render an <div> tag', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.type()).toEqual('div');
+    const { container } = render(<Wrapper />);
+    expect(container.firstElementChild.tagName).toEqual('DIV');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<Wrapper />);
+    const element = container.firstElementChild;
+    expect(element.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<Wrapper id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<Wrapper id={id} />);
+    const element = container.firstElementChild;
+    expect(element.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<Wrapper attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<Wrapper attribute="test" />);
+    const element = container.firstElementChild;
+    expect(element.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/components/List/tests/index.test.js
+++ b/app/components/List/tests/index.test.js
@@ -1,35 +1,28 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
-import ListItem from 'components/ListItem';
 import List from '../index';
 
 describe('<List />', () => {
-  it('should render the component if no items are passed', () => {
-    const renderedComponent = shallow(<List component={ListItem} />);
-    expect(renderedComponent.find(ListItem)).toBeDefined();
+  afterEach(cleanup);
+
+  it('should render the passed component if no items are passed', () => {
+    const component = () => <li>test</li>; // eslint-disable-line react/prop-types
+    const { container } = render(<List component={component} />);
+    expect(container.querySelector('li')).not.toBeNull();
   });
 
   it('should pass all items props to rendered component', () => {
     const items = [{ id: 1, name: 'Hello' }, { id: 2, name: 'World' }];
 
-    const component = ({ item }) => <ListItem>{item.name}</ListItem>; // eslint-disable-line react/prop-types
+    const component = ({ item }) => <li>{item.name}</li>; // eslint-disable-line react/prop-types
 
-    const renderedComponent = shallow(
+    const { container, getByText } = render(
       <List items={items} component={component} />,
     );
-    expect(renderedComponent.find(component)).toHaveLength(2);
-    expect(
-      renderedComponent
-        .find(component)
-        .at(0)
-        .prop('item'),
-    ).toBe(items[0]);
-    expect(
-      renderedComponent
-        .find(component)
-        .at(1)
-        .prop('item'),
-    ).toBe(items[1]);
+    const elements = container.querySelectorAll('li');
+    expect(elements).toHaveLength(2);
+    expect(getByText(items[0].name)).not.toBeNull();
+    expect(getByText(items[1].name)).not.toBeNull();
   });
 });

--- a/app/components/ListItem/tests/Item.test.js
+++ b/app/components/ListItem/tests/Item.test.js
@@ -1,27 +1,30 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Item from '../Item';
 
 describe('<Item />', () => {
+  afterEach(cleanup);
+
   it('should render an <div> tag', () => {
-    const renderedComponent = shallow(<Item />);
-    expect(renderedComponent.type()).toEqual('div');
+    const { container } = render(<Item />);
+    expect(container.firstChild.tagName).toEqual('DIV');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<Item />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<Item />);
+    expect(container.firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<Item id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<Item id={id} />);
+    expect(container.firstChild.hasAttribute('id')).toBe(true);
+    expect(container.firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<Item attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<Item attribute="test" />);
+    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/components/ListItem/tests/Wrapper.test.js
+++ b/app/components/ListItem/tests/Wrapper.test.js
@@ -1,27 +1,34 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
+  afterEach(cleanup);
+
   it('should render an <li> tag', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.type()).toEqual('li');
+    const { container } = render(<Wrapper />);
+    const element = container.querySelector('li');
+    expect(element).not.toBeNull();
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<Wrapper />);
+    const element = container.querySelector('li');
+    expect(element.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<Wrapper id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<Wrapper id={id} />);
+    const element = container.querySelector('li');
+    expect(element.hasAttribute('id')).toBe(true);
+    expect(element.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<Wrapper attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<Wrapper attribute="test" />);
+    const element = container.querySelector('li');
+    expect(element.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/components/ListItem/tests/index.test.js
+++ b/app/components/ListItem/tests/index.test.js
@@ -1,17 +1,21 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
+import 'jest-dom/extend-expect';
 
 import ListItem from '../index';
 
 describe('<ListItem />', () => {
-  it('should have a className', () => {
-    const renderedComponent = mount(<ListItem className="test" />);
-    expect(renderedComponent.find('li').prop('className')).toBeDefined();
+  afterEach(cleanup);
+
+  it('should have a class', () => {
+    const { container } = render(<ListItem className="test" />);
+    expect(container.querySelector('li').hasAttribute('class')).toBe(true);
   });
 
   it('should render the content passed to it', () => {
-    const content = <div>Hello world!</div>;
-    const renderedComponent = mount(<ListItem item={content} />);
-    expect(renderedComponent.contains(content)).toBe(true);
+    const content = <div data-testid="test">Hello world!</div>;
+    const { getByTestId } = render(<ListItem item={content} />);
+    expect(getByTestId('test').tagName).toEqual('DIV');
+    expect(getByTestId('test')).toHaveTextContent('Hello world!');
   });
 });

--- a/app/components/LoadingIndicator/tests/Circle.test.js
+++ b/app/components/LoadingIndicator/tests/Circle.test.js
@@ -1,22 +1,24 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Circle from '../Circle';
 
 describe('<Circle />', () => {
+  afterEach(cleanup);
+
   it('should render an <div> tag', () => {
-    const renderedComponent = mount(<Circle />);
-    expect(renderedComponent.find('div')).toHaveLength(1);
+    const { container } = render(<Circle />);
+    expect(container.firstChild.tagName).toEqual('DIV');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = mount(<Circle />);
-    expect(renderedComponent.find('div').prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<Circle />);
+    expect(container.firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should not adopt attributes', () => {
     const id = 'test';
-    const renderedComponent = mount(<Circle id={id} />);
-    expect(renderedComponent.find('div').prop('id')).toBeUndefined();
+    const { container } = render(<Circle id={id} />);
+    expect(container.firstChild.hasAttribute('id')).toBe(false);
   });
 });

--- a/app/components/LoadingIndicator/tests/Circle.test.js
+++ b/app/components/LoadingIndicator/tests/Circle.test.js
@@ -6,7 +6,7 @@ import Circle from '../Circle';
 describe('<Circle />', () => {
   it('should render an <div> tag', () => {
     const renderedComponent = mount(<Circle />);
-    expect(renderedComponent.find('div').length).toEqual(1);
+    expect(renderedComponent.find('div')).toHaveLength(1);
   });
 
   it('should have a className attribute', () => {

--- a/app/components/LoadingIndicator/tests/Wrapper.test.js
+++ b/app/components/LoadingIndicator/tests/Wrapper.test.js
@@ -1,27 +1,32 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
+  afterEach(cleanup);
+
   it('should render an <div> tag', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.type()).toEqual('div');
+    const { container } = render(<Wrapper />);
+    expect(container.firstElementChild.tagName).toEqual('DIV');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<Wrapper />);
+    const element = container.firstElementChild;
+    expect(element.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<Wrapper id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<Wrapper id={id} />);
+    const element = container.firstElementChild;
+    expect(element.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<Wrapper attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<Wrapper attribute="test" />);
+    const element = container.firstElementChild;
+    expect(element.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/components/ReposList/tests/__snapshots__/index.test.js.snap
+++ b/app/components/ReposList/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ReposList /> should render the loading indicator when its loading 1`] = `
+<div
+  class="Wrapper-ThVjl egVNqX"
+>
+  <ul
+    class="Ul-bfMUEV bbRdqs"
+  >
+    <div
+      class="Wrapper-ThVjl bNvReZ"
+    >
+      <div
+        class="Circle__CirclePrimitive-cPqaOG ehmTAR"
+      />
+      <div
+        class="Circle__CirclePrimitive-cPqaOG zdGXL"
+      />
+      <div
+        class="Circle__CirclePrimitive-cPqaOG hZmZmt"
+      />
+      <div
+        class="Circle__CirclePrimitive-cPqaOG hmjUiu"
+      />
+      <div
+        class="Circle__CirclePrimitive-cPqaOG SCPwQ"
+      />
+      <div
+        class="Circle__CirclePrimitive-cPqaOG drXvaa"
+      />
+      <div
+        class="Circle__CirclePrimitive-cPqaOG OJgdC"
+      />
+      <div
+        class="Circle__CirclePrimitive-cPqaOG gZiMKx"
+      />
+      <div
+        class="Circle__CirclePrimitive-cPqaOG okLMH"
+      />
+      <div
+        class="Circle__CirclePrimitive-cPqaOG eaNyAy"
+      />
+      <div
+        class="Circle__CirclePrimitive-cPqaOG eJcvxt"
+      />
+      <div
+        class="Circle__CirclePrimitive-cPqaOG iUFKZk"
+      />
+    </div>
+  </ul>
+</div>
+`;
+
+exports[`<ReposList /> should render the repositories if loading was successful 1`] = `
+<div
+  class="Wrapper-ThVjl egVNqX"
+>
+  <ul
+    class="Ul-bfMUEV bbRdqs"
+  >
+    <li
+      class="Wrapper-ThVjl dVNtAR"
+    >
+      <div
+        class="Item-kPuYOm jbfpqt"
+      >
+        <div
+          class="Wrapper-ThVjl hcTMtI"
+        >
+          <a
+            class="A-bJefwH kvvqog"
+            href="https://github.com/react-boilerplate/react-boilerplate"
+            target="_blank"
+          >
+            react-boilerplate
+          </a>
+          <a
+            class="A-bJefwH eMsNvo"
+            href="https://github.com/react-boilerplate/react-boilerplate/issues"
+            target="_blank"
+          >
+            <svg
+              class="IssueIcon-jDeGlB krkxAt"
+              height="1em"
+              width="0.875em"
+            >
+              <path
+                d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7S10.14 13.7 7 13.7 1.3 11.14 1.3 8s2.56-5.7 5.7-5.7m0-1.3C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7S10.86 1 7 1z m1 3H6v5h2V4z m0 6H6v2h2V10z"
+              />
+            </svg>
+            <span>
+              20
+            </span>
+          </a>
+        </div>
+      </div>
+    </li>
+  </ul>
+</div>
+`;

--- a/app/components/ReposList/tests/index.test.js
+++ b/app/components/ReposList/tests/index.test.js
@@ -1,30 +1,34 @@
-import { shallow, mount } from 'enzyme';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
+import { browserHistory } from 'react-router-dom';
+import { cleanup, render } from 'react-testing-library';
 
-import RepoListItem from 'containers/RepoListItem';
-import List from 'components/List';
-import LoadingIndicator from 'components/LoadingIndicator';
 import ReposList from '../index';
+import configureStore from '../../../configureStore';
 
 describe('<ReposList />', () => {
+  afterEach(cleanup);
+
   it('should render the loading indicator when its loading', () => {
-    const renderedComponent = shallow(<ReposList loading />);
-    expect(
-      renderedComponent.contains(<List component={LoadingIndicator} />),
-    ).toEqual(true);
+    const { container } = render(<ReposList loading />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should render an error if loading failed', () => {
-    const renderedComponent = mount(
+    const { queryByText } = render(
       <IntlProvider locale="en">
         <ReposList loading={false} error={{ message: 'Loading failed!' }} />
       </IntlProvider>,
     );
-    expect(renderedComponent.text()).toMatch(/Something went wrong/);
+    expect(queryByText(/Something went wrong/)).not.toBeNull();
   });
 
   it('should render the repositories if loading was successful', () => {
+    const store = configureStore(
+      { global: { currentUser: 'mxstbr' } },
+      browserHistory,
+    );
     const repos = [
       {
         owner: {
@@ -36,22 +40,22 @@ describe('<ReposList />', () => {
         full_name: 'react-boilerplate/react-boilerplate',
       },
     ];
-    const renderedComponent = shallow(
-      <ReposList repos={repos} error={false} />,
+    const { container } = render(
+      <Provider store={store}>
+        <IntlProvider locale="en">
+          <ReposList repos={repos} error={false} />
+        </IntlProvider>
+      </Provider>,
     );
 
-    expect(
-      renderedComponent.contains(
-        <List items={repos} component={RepoListItem} />,
-      ),
-    ).toEqual(true);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should not render anything if nothing interesting is provided', () => {
-    const renderedComponent = shallow(
+    const { container } = render(
       <ReposList repos={false} error={false} loading={false} />,
     );
 
-    expect(renderedComponent.html()).toEqual(null);
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/app/components/Toggle/tests/Select.test.js
+++ b/app/components/Toggle/tests/Select.test.js
@@ -1,27 +1,29 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Select from '../Select';
 
 describe('<Select />', () => {
+  afterEach(cleanup);
+
   it('should render an <select> tag', () => {
-    const renderedComponent = shallow(<Select />);
-    expect(renderedComponent.type()).toEqual('select');
+    const { container } = render(<Select />);
+    expect(container.firstChild.tagName).toEqual('SELECT');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<Select />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<Select />);
+    expect(container.firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<Select id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<Select id={id} />);
+    expect(container.firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<Select attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<Select attribute="test" />);
+    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/components/Toggle/tests/__snapshots__/index.test.js.snap
+++ b/app/components/Toggle/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Toggle /> should contain default text 1`] = `
+<select
+  class="Select-eZBaHc btkmX"
+>
+  <option
+    value="en"
+  >
+    someContent
+  </option>
+  <option
+    value="de"
+  >
+    someOtherContent
+  </option>
+</select>
+`;

--- a/app/components/Toggle/tests/index.test.js
+++ b/app/components/Toggle/tests/index.test.js
@@ -1,10 +1,12 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 import { IntlProvider, defineMessages } from 'react-intl';
 
 import Toggle from '../index';
 
 describe('<Toggle />', () => {
+  afterEach(cleanup);
+
   it('should contain default text', () => {
     const defaultEnMessage = 'someContent';
     const defaultDeMessage = 'someOtherContent';
@@ -18,21 +20,18 @@ describe('<Toggle />', () => {
         defaultMessage: defaultDeMessage,
       },
     });
-    const renderedComponent = shallow(
+    const { container } = render(
       <IntlProvider locale="en">
         <Toggle values={['en', 'de']} messages={messages} />
       </IntlProvider>,
     );
-    expect(
-      renderedComponent.contains(
-        <Toggle values={['en', 'de']} messages={messages} />,
-      ),
-    ).toBe(true);
-    expect(renderedComponent.find('option')).toHaveLength(0);
+    expect(container.firstChild).toMatchSnapshot();
   });
+
   it('should not have ToggleOptions if props.values is not defined', () => {
-    const renderedComponent = shallow(<Toggle />);
-    expect(renderedComponent.contains(<option>--</option>)).toBe(true);
-    expect(renderedComponent.find('option')).toHaveLength(1);
+    const { container } = render(<Toggle />);
+    const elements = container.querySelectorAll('option');
+    expect(elements).toHaveLength(1);
+    expect(container.firstChild.value).toEqual('--');
   });
 });

--- a/app/components/Toggle/tests/index.test.js
+++ b/app/components/Toggle/tests/index.test.js
@@ -28,11 +28,11 @@ describe('<Toggle />', () => {
         <Toggle values={['en', 'de']} messages={messages} />,
       ),
     ).toBe(true);
-    expect(renderedComponent.find('option').length).toBe(0);
+    expect(renderedComponent.find('option')).toHaveLength(0);
   });
   it('should not have ToggleOptions if props.values is not defined', () => {
     const renderedComponent = shallow(<Toggle />);
     expect(renderedComponent.contains(<option>--</option>)).toBe(true);
-    expect(renderedComponent.find('option').length).toBe(1);
+    expect(renderedComponent.find('option')).toHaveLength(1);
   });
 });

--- a/app/components/ToggleOption/tests/__snapshots__/index.test.js.snap
+++ b/app/components/ToggleOption/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ToggleOption /> should render default language messages 1`] = `
+<option
+  value="en"
+>
+  someContent
+</option>
+`;

--- a/app/components/ToggleOption/tests/index.test.js
+++ b/app/components/ToggleOption/tests/index.test.js
@@ -1,10 +1,12 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 import { IntlProvider, defineMessages } from 'react-intl';
 
 import ToggleOption from '../index';
 
 describe('<ToggleOption />', () => {
+  afterEach(cleanup);
+
   it('should render default language messages', () => {
     const defaultEnMessage = 'someContent';
     const message = defineMessages({
@@ -13,24 +15,20 @@ describe('<ToggleOption />', () => {
         defaultMessage: defaultEnMessage,
       },
     });
-    const renderedComponent = shallow(
+    const { container } = render(
       <IntlProvider locale="en">
         <ToggleOption value="en" message={message.enMessage} />
       </IntlProvider>,
     );
-    expect(
-      renderedComponent.contains(
-        <ToggleOption value="en" message={message.enMessage} />,
-      ),
-    ).toBe(true);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should display `value`(two letter language code) when `message` is absent', () => {
-    const renderedComponent = mount(
+    const { queryByText } = render(
       <IntlProvider locale="de">
         <ToggleOption value="de" />
       </IntlProvider>,
     );
-    expect(renderedComponent.text()).toBe('de');
+    expect(queryByText('de')).toBeDefined();
   });
 });

--- a/app/containers/App/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/App/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<App /> should render and match the snapshot 1`] = `
+<App__AppWrapper>
+  <HelmetWrapper
+    defaultTitle="React.js Boilerplate"
+    defer={true}
+    encodeSpecialCharacters={true}
+    titleTemplate="%s - React.js Boilerplate"
+  >
+    <meta
+      content="A React.js Boilerplate application"
+      name="description"
+    />
+  </HelmetWrapper>
+  <Header />
+  <Switch>
+    <Route
+      component={[Function]}
+      exact={true}
+      path="/"
+    />
+    <Route
+      component={[Function]}
+      path="/features"
+    />
+    <Route
+      component={[Function]}
+      path=""
+    />
+  </Switch>
+  <Footer />
+</App__AppWrapper>
+`;

--- a/app/containers/App/tests/index.test.js
+++ b/app/containers/App/tests/index.test.js
@@ -9,16 +9,16 @@ import App from '../index';
 describe('<App />', () => {
   it('should render the header', () => {
     const renderedComponent = shallow(<App />);
-    expect(renderedComponent.find(Header).length).toBe(1);
+    expect(renderedComponent.find(Header)).toHaveLength(1);
   });
 
   it('should render some routes', () => {
     const renderedComponent = shallow(<App />);
-    expect(renderedComponent.find(Route).length).not.toBe(0);
+    expect(renderedComponent.find(Route)).not.toHaveLength(0);
   });
 
   it('should render the footer', () => {
     const renderedComponent = shallow(<App />);
-    expect(renderedComponent.find(Footer).length).toBe(1);
+    expect(renderedComponent.find(Footer)).toHaveLength(1);
   });
 });

--- a/app/containers/App/tests/index.test.js
+++ b/app/containers/App/tests/index.test.js
@@ -1,24 +1,14 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { Route } from 'react-router-dom';
+import ShallowRenderer from 'react-test-renderer/shallow';
 
-import Header from 'components/Header';
-import Footer from 'components/Footer';
 import App from '../index';
 
+const renderer = new ShallowRenderer();
+
 describe('<App />', () => {
-  it('should render the header', () => {
-    const renderedComponent = shallow(<App />);
-    expect(renderedComponent.find(Header)).toHaveLength(1);
-  });
-
-  it('should render some routes', () => {
-    const renderedComponent = shallow(<App />);
-    expect(renderedComponent.find(Route)).not.toHaveLength(0);
-  });
-
-  it('should render the footer', () => {
-    const renderedComponent = shallow(<App />);
-    expect(renderedComponent.find(Footer)).toHaveLength(1);
+  it('should render and match the snapshot', () => {
+    renderer.render(<App />);
+    const renderedOutput = renderer.getRenderOutput();
+    expect(renderedOutput).toMatchSnapshot();
   });
 });

--- a/app/containers/FeaturePage/tests/List.test.js
+++ b/app/containers/FeaturePage/tests/List.test.js
@@ -1,27 +1,37 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import List from '../List';
 
 describe('<List />', () => {
+  afterEach(cleanup);
+
   it('should render an <ul> tag', () => {
-    const renderedComponent = shallow(<List />);
-    expect(renderedComponent.type()).toEqual('ul');
+    const {
+      container: { firstChild },
+    } = render(<List />);
+    expect(firstChild.tagName).toEqual('UL');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<List />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const {
+      container: { firstChild },
+    } = render(<List />);
+    expect(firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<List id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const {
+      container: { firstChild },
+    } = render(<List id={id} />);
+    expect(firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<List attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const {
+      container: { firstChild },
+    } = render(<List attribute="test" />);
+    expect(firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/containers/FeaturePage/tests/ListItem.test.js
+++ b/app/containers/FeaturePage/tests/ListItem.test.js
@@ -1,27 +1,37 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import ListItem from '../ListItem';
 
 describe('<ListItem />', () => {
+  afterEach(cleanup);
+
   it('should render an <li> tag', () => {
-    const renderedComponent = shallow(<ListItem />);
-    expect(renderedComponent.type()).toEqual('li');
+    const {
+      container: { firstChild },
+    } = render(<ListItem />);
+    expect(firstChild.tagName).toEqual('LI');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<ListItem />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const {
+      container: { firstChild },
+    } = render(<ListItem />);
+    expect(firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<ListItem id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const {
+      container: { firstChild },
+    } = render(<ListItem id={id} />);
+    expect(firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<ListItem attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const {
+      container: { firstChild },
+    } = render(<ListItem attribute="test" />);
+    expect(firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/containers/FeaturePage/tests/ListItemTitle.test.js
+++ b/app/containers/FeaturePage/tests/ListItemTitle.test.js
@@ -1,27 +1,37 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import ListItemTitle from '../ListItemTitle';
 
 describe('<ListItemTitle />', () => {
+  afterEach(cleanup);
+
   it('should render an <p> tag', () => {
-    const renderedComponent = shallow(<ListItemTitle />);
-    expect(renderedComponent.type()).toEqual('p');
+    const {
+      container: { firstChild },
+    } = render(<ListItemTitle />);
+    expect(firstChild.tagName).toEqual('P');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<ListItemTitle />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const {
+      container: { firstChild },
+    } = render(<ListItemTitle />);
+    expect(firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<ListItemTitle id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const {
+      container: { firstChild },
+    } = render(<ListItemTitle id={id} />);
+    expect(firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<ListItemTitle attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const {
+      container: { firstChild },
+    } = render(<ListItemTitle attribute="test" />);
+    expect(firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/containers/FeaturePage/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/FeaturePage/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FeaturePage /> should render its heading 1`] = `
+<div>
+  <h1
+    class="H1-gsrphG KFgCL"
+  >
+    <span>
+      Features
+    </span>
+  </h1>
+  <ul
+    class="List-htqUMz fYAZUf"
+  >
+    <li
+      class="ListItem-llUgLb fXPHFb"
+    >
+      <p
+        class="ListItemTitle-cggURC gWwIVT"
+      >
+        <span>
+          Quick scaffolding
+        </span>
+      </p>
+      <p>
+        <span>
+          Automate the creation of components, containers, routes, selectors
+  and sagas - and their tests - right from the CLI!
+        </span>
+      </p>
+    </li>
+    <li
+      class="ListItem-llUgLb fXPHFb"
+    >
+      <p
+        class="ListItemTitle-cggURC gWwIVT"
+      >
+        <span>
+          Instant feedback
+        </span>
+      </p>
+      <p>
+        <span>
+          
+      Enjoy the best DX and code your app at the speed of thought! Your
+    saved changes to the CSS and JS are reflected instantaneously
+    without refreshing the page. Preserve application state even when
+    you update something in the underlying code!
+    
+        </span>
+      </p>
+    </li>
+    <li
+      class="ListItem-llUgLb fXPHFb"
+    >
+      <p
+        class="ListItemTitle-cggURC gWwIVT"
+      >
+        <span>
+          Industry-standard routing
+        </span>
+      </p>
+      <p>
+        <span>
+          
+      Write composable CSS that's co-located with your components for
+    complete modularity. Unique generated class names keep the
+    specificity low while eliminating style clashes. Ship only the
+    styles that are on the page for the best performance.
+    
+        </span>
+      </p>
+    </li>
+    <li
+      class="ListItem-llUgLb fXPHFb"
+    >
+      <p
+        class="ListItemTitle-cggURC gWwIVT"
+      >
+        <span>
+          Offline-first
+        </span>
+      </p>
+      <p>
+        <span>
+          
+      The next frontier in performant web apps: availability without a
+      network connection from the instant your users load the app.
+    
+        </span>
+      </p>
+    </li>
+    <li
+      class="ListItem-llUgLb fXPHFb"
+    >
+      <p
+        class="ListItemTitle-cggURC gWwIVT"
+      >
+        <span>
+          Complete i18n Standard Internationalization & Pluralization
+        </span>
+      </p>
+      <p>
+        <span>
+          Scalable apps need to support multiple languages, easily add and support multiple languages with \`react-intl\`.
+        </span>
+      </p>
+    </li>
+  </ul>
+</div>
+`;

--- a/app/containers/FeaturePage/tests/index.test.js
+++ b/app/containers/FeaturePage/tests/index.test.js
@@ -1,26 +1,41 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { FormattedMessage } from 'react-intl';
+import { cleanup, render } from 'react-testing-library';
+import { IntlProvider } from 'react-intl';
 
-import H1 from 'components/H1';
-import messages from '../messages';
 import FeaturePage from '../index';
 
 describe('<FeaturePage />', () => {
+  afterEach(cleanup);
+
   it('should render its heading', () => {
-    const renderedComponent = shallow(<FeaturePage />);
-    expect(
-      renderedComponent.contains(
-        <H1>
-          <FormattedMessage {...messages.header} />
-        </H1>,
-      ),
-    ).toBe(true);
+    const {
+      container: { firstChild },
+    } = render(
+      <IntlProvider locale="en">
+        <FeaturePage />
+      </IntlProvider>,
+    );
+
+    expect(firstChild).toMatchSnapshot();
   });
 
   it('should never re-render the component', () => {
-    const renderedComponent = shallow(<FeaturePage />);
-    const inst = renderedComponent.instance();
-    expect(inst.shouldComponentUpdate()).toBe(false);
+    const shouldComponentUpdateMock = jest.spyOn(
+      FeaturePage.prototype,
+      'shouldComponentUpdate',
+    );
+    const { rerender } = render(
+      <IntlProvider locale="en">
+        <FeaturePage />
+      </IntlProvider>,
+    );
+
+    rerender(
+      <IntlProvider locale="en">
+        <FeaturePage test="dummy" />
+      </IntlProvider>,
+    );
+
+    expect(shouldComponentUpdateMock).toHaveReturnedWith(false);
   });
 });

--- a/app/containers/HomePage/tests/AtPrefix.test.js
+++ b/app/containers/HomePage/tests/AtPrefix.test.js
@@ -1,27 +1,37 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import AtPrefix from '../AtPrefix';
 
 describe('<AtPrefix />', () => {
+  afterEach(cleanup);
+
   it('should render an <span> tag', () => {
-    const renderedComponent = shallow(<AtPrefix />);
-    expect(renderedComponent.type()).toEqual('span');
+    const {
+      container: { firstChild },
+    } = render(<AtPrefix />);
+    expect(firstChild.tagName).toEqual('SPAN');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<AtPrefix />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const {
+      container: { firstChild },
+    } = render(<AtPrefix />);
+    expect(firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<AtPrefix id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const {
+      container: { firstChild },
+    } = render(<AtPrefix id={id} />);
+    expect(firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<AtPrefix attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const {
+      container: { firstChild },
+    } = render(<AtPrefix attribute="test" />);
+    expect(firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/containers/HomePage/tests/CenteredSection.test.js
+++ b/app/containers/HomePage/tests/CenteredSection.test.js
@@ -1,27 +1,37 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import CenteredSection from '../CenteredSection';
 
 describe('<CenteredSection />', () => {
+  afterEach(cleanup);
+
   it('should render an <section> tag', () => {
-    const renderedComponent = shallow(<CenteredSection />);
-    expect(renderedComponent.type()).toEqual('section');
+    const {
+      container: { firstChild },
+    } = render(<CenteredSection />);
+    expect(firstChild.tagName).toEqual('SECTION');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<CenteredSection />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const {
+      container: { firstChild },
+    } = render(<CenteredSection />);
+    expect(firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<CenteredSection id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const {
+      container: { firstChild },
+    } = render(<CenteredSection id={id} />);
+    expect(firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<CenteredSection attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const {
+      container: { firstChild },
+    } = render(<CenteredSection attribute="test" />);
+    expect(firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/containers/HomePage/tests/Form.test.js
+++ b/app/containers/HomePage/tests/Form.test.js
@@ -1,27 +1,37 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Form from '../Form';
 
 describe('<Form />', () => {
+  afterEach(cleanup);
+
   it('should render an <form> tag', () => {
-    const renderedComponent = shallow(<Form />);
-    expect(renderedComponent.type()).toEqual('form');
+    const {
+      container: { firstChild },
+    } = render(<Form />);
+    expect(firstChild.tagName).toEqual('FORM');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<Form />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const {
+      container: { firstChild },
+    } = render(<Form />);
+    expect(firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<Form id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const {
+      container: { firstChild },
+    } = render(<Form id={id} />);
+    expect(firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<Form attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const {
+      container: { firstChild },
+    } = render(<Form attribute="test" />);
+    expect(firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/containers/HomePage/tests/Input.test.js
+++ b/app/containers/HomePage/tests/Input.test.js
@@ -1,27 +1,29 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Input from '../Input';
 
 describe('<Input />', () => {
+  afterEach(cleanup);
+
   it('should render an <input> tag', () => {
-    const renderedComponent = shallow(<Input />);
-    expect(renderedComponent.type()).toEqual('input');
+    const { container } = render(<Input />);
+    expect(container.firstChild.tagName).toEqual('INPUT');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<Input />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<Input />);
+    expect(container.firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<Input id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<Input id={id} />);
+    expect(container.firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<Input attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<Input attribute="test" />);
+    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/containers/HomePage/tests/Section.test.js
+++ b/app/containers/HomePage/tests/Section.test.js
@@ -1,27 +1,29 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Section from '../Section';
 
 describe('<Section />', () => {
+  afterEach(cleanup);
+
   it('should render an <section> tag', () => {
-    const renderedComponent = shallow(<Section />);
-    expect(renderedComponent.type()).toEqual('section');
+    const { container } = render(<Section />);
+    expect(container.firstChild.tagName).toEqual('SECTION');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<Section />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<Section />);
+    expect(container.firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<Section id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<Section id={id} />);
+    expect(container.firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<Section attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<Section attribute="test" />);
+    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/containers/HomePage/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/HomePage/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<HomePage /> should render and match the snapshot 1`] = `
+<article>
+  <div>
+    <section
+      class="Section-kjlTVo fyoxrz"
+    >
+      <h2
+        class="H2-eUbBFj foTfOk"
+      >
+        <span>
+          Start your next react project in seconds
+        </span>
+      </h2>
+      <p>
+        <span>
+          A highly scalable, offline-first foundation with the best DX and a focus on performance and best practices
+        </span>
+      </p>
+    </section>
+    <section
+      class="Section-kjlTVo iwZUVc"
+    >
+      <h2
+        class="H2-eUbBFj foTfOk"
+      >
+        <span>
+          Try me!
+        </span>
+      </h2>
+      <form
+        class="Form-dhHGoS dsIrGS"
+      >
+        <label
+          for="username"
+        >
+          <span>
+            Show Github repositories by
+          </span>
+          <span
+            class="AtPrefix-dDnKjs bSAVub"
+          >
+            <span>
+              @
+            </span>
+          </span>
+          <input
+            class="Input-hxTtdt dCkjYH"
+            id="username"
+            placeholder="mxstbr"
+            type="text"
+            value=""
+          />
+        </label>
+      </form>
+      <div
+        class="Wrapper-ThVjl egVNqX"
+      >
+        <ul
+          class="Ul-bfMUEV bbRdqs"
+        />
+      </div>
+    </section>
+  </div>
+</article>
+`;

--- a/app/containers/HomePage/tests/index.test.js
+++ b/app/containers/HomePage/tests/index.test.js
@@ -3,29 +3,30 @@
  */
 
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 import { IntlProvider } from 'react-intl';
 
-import ReposList from 'components/ReposList';
 import { HomePage, mapDispatchToProps } from '../index';
 import { changeUsername } from '../actions';
 import { loadRepos } from '../../App/actions';
 
 describe('<HomePage />', () => {
-  it('should render the repos list', () => {
-    const renderedComponent = shallow(
-      <HomePage loading error={false} repos={[]} />,
+  afterEach(cleanup);
+
+  it('should render and match the snapshot', () => {
+    const {
+      container: { firstChild },
+    } = render(
+      <IntlProvider locale="en">
+        <HomePage loading={false} error={false} repos={[]} />
+      </IntlProvider>,
     );
-    expect(
-      renderedComponent.contains(
-        <ReposList loading error={false} repos={[]} />,
-      ),
-    ).toEqual(true);
+    expect(firstChild).toMatchSnapshot();
   });
 
   it('should render fetch the repos on mount if a username exists', () => {
     const submitSpy = jest.fn();
-    mount(
+    render(
       <IntlProvider locale="en">
         <HomePage
           username="Not Empty"
@@ -39,7 +40,7 @@ describe('<HomePage />', () => {
 
   it('should not call onSubmitForm if username is an empty string', () => {
     const submitSpy = jest.fn();
-    mount(
+    render(
       <IntlProvider locale="en">
         <HomePage onChangeUsername={() => {}} onSubmitForm={submitSpy} />
       </IntlProvider>,
@@ -49,7 +50,7 @@ describe('<HomePage />', () => {
 
   it('should not call onSubmitForm if username is null', () => {
     const submitSpy = jest.fn();
-    mount(
+    render(
       <IntlProvider locale="en">
         <HomePage
           username=""

--- a/app/containers/LanguageProvider/tests/index.test.js
+++ b/app/containers/LanguageProvider/tests/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { Provider } from 'react-redux';
 import { browserHistory } from 'react-router-dom';
@@ -18,14 +18,16 @@ const messages = defineMessages({
 });
 
 describe('<LanguageProvider />', () => {
+  afterEach(cleanup);
+
   it('should render its children', () => {
     const children = <h1>Test</h1>;
-    const renderedComponent = shallow(
+    const { container } = render(
       <LanguageProvider messages={messages} locale="en">
         {children}
       </LanguageProvider>,
     );
-    expect(renderedComponent.contains(children)).toBe(true);
+    expect(container.firstChild).not.toBeNull();
   });
 });
 
@@ -36,18 +38,16 @@ describe('<ConnectedLanguageProvider />', () => {
     store = configureStore({}, browserHistory);
   });
 
+  afterEach(cleanup);
+
   it('should render the default language messages', () => {
-    const renderedComponent = mount(
+    const { queryByText } = render(
       <Provider store={store}>
         <ConnectedLanguageProvider messages={translationMessages}>
           <FormattedMessage {...messages.someMessage} />
         </ConnectedLanguageProvider>
       </Provider>,
     );
-    expect(
-      renderedComponent.contains(
-        <FormattedMessage {...messages.someMessage} />,
-      ),
-    ).toBe(true);
+    expect(queryByText(messages.someMessage.defaultMessage)).not.toBeNull();
   });
 });

--- a/app/containers/LocaleToggle/tests/Wrapper.test.js
+++ b/app/containers/LocaleToggle/tests/Wrapper.test.js
@@ -1,27 +1,30 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
+  afterEach(cleanup);
+
   it('should render an <div> tag', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.type()).toEqual('div');
+    const { container } = render(<Wrapper />);
+    expect(container.firstChild.tagName).toEqual('DIV');
   });
 
-  it('should have a className attribute', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+  it('should have a class attribute', () => {
+    const { container } = render(<Wrapper />);
+    expect(container.firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<Wrapper id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<Wrapper id={id} />);
+    expect(container.firstChild.hasAttribute('id')).toBe(true);
+    expect(container.firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<Wrapper attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<Wrapper attribute="test" />);
+    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/containers/LocaleToggle/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/LocaleToggle/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<LocaleToggle /> should match the snapshot 1`] = `
+<div
+  class="Wrapper-ThVjl eCtFPq"
+>
+  <select
+    class="Select-eZBaHc btkmX"
+  >
+    <option
+      value="en"
+    >
+      en
+    </option>
+    <option
+      value="de"
+    >
+      de
+    </option>
+  </select>
+</div>
+`;

--- a/app/containers/LocaleToggle/tests/index.test.js
+++ b/app/containers/LocaleToggle/tests/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { browserHistory } from 'react-router-dom';
-import { shallow, mount } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import LocaleToggle, { mapDispatchToProps } from '../index';
 import { changeLocale } from '../../LanguageProvider/actions';
@@ -17,28 +17,28 @@ describe('<LocaleToggle />', () => {
     store = configureStore({}, browserHistory);
   });
 
-  it('should render the default language messages', () => {
-    const renderedComponent = shallow(
+  afterEach(cleanup);
+
+  it('should match the snapshot', () => {
+    const { container } = render(
       <Provider store={store}>
         <LanguageProvider messages={translationMessages}>
           <LocaleToggle />
         </LanguageProvider>
       </Provider>,
     );
-    expect(renderedComponent.contains(<LocaleToggle />)).toBe(true);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should present the default `en` english language option', () => {
-    const renderedComponent = mount(
+    const { container } = render(
       <Provider store={store}>
         <LanguageProvider messages={translationMessages}>
           <LocaleToggle />
         </LanguageProvider>
       </Provider>,
     );
-    expect(renderedComponent.contains(<option value="en">en</option>)).toBe(
-      true,
-    );
+    expect(container.querySelector('option[value="en"]')).not.toBeNull();
   });
 
   describe('mapDispatchToProps', () => {

--- a/app/containers/NotFoundPage/tests/index.test.js
+++ b/app/containers/NotFoundPage/tests/index.test.js
@@ -3,24 +3,21 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
-import { FormattedMessage } from 'react-intl';
+import { cleanup, render } from 'react-testing-library';
+import { IntlProvider } from 'react-intl';
 
-import H1 from 'components/H1';
 import NotFound from '../index';
+import messages from '../messages';
 
 describe('<NotFound />', () => {
+  afterEach(cleanup);
+
   it('should render the Page Not Found text', () => {
-    const renderedComponent = shallow(<NotFound />);
-    expect(
-      renderedComponent.contains(
-        <H1>
-          <FormattedMessage
-            id="boilerplate.containers.NotFoundPage.header"
-            defaultMessage="Page not found."
-          />
-        </H1>,
-      ),
-    ).toEqual(true);
+    const { queryByText } = render(
+      <IntlProvider locale="en">
+        <NotFound />
+      </IntlProvider>,
+    );
+    expect(queryByText(messages.header.defaultMessage)).not.toBeNull();
   });
 });

--- a/app/containers/RepoListItem/tests/IssueIcon.test.js
+++ b/app/containers/RepoListItem/tests/IssueIcon.test.js
@@ -1,29 +1,32 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import IssueIcon from '../IssueIcon';
 
 describe('<IssueIcon />', () => {
+  afterEach(cleanup);
+
   it('should match the snapshot', () => {
     const renderedComponent = renderer.create(<IssueIcon />).toJSON();
     expect(renderedComponent).toMatchSnapshot();
   });
 
   it('should have a className attribute', () => {
-    const renderedComponent = shallow(<IssueIcon />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+    const { container } = render(<IssueIcon />);
+    expect(container.firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<IssueIcon id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<IssueIcon id={id} />);
+    expect(container.firstChild.hasAttribute('id')).toBe(true);
+    expect(container.firstChild.id).toEqual(id);
   });
 
   it('should adopt any attribute', () => {
-    const renderedComponent = shallow(<IssueIcon attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeDefined();
+    const { container } = render(<IssueIcon attribute="test" />);
+    expect(container.firstChild.hasAttribute('attribute')).toBe(true);
   });
 });

--- a/app/containers/RepoListItem/tests/IssueLink.test.js
+++ b/app/containers/RepoListItem/tests/IssueLink.test.js
@@ -1,29 +1,32 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import IssueLink from '../IssueLink';
 
 describe('<IssueLink />', () => {
+  afterEach(cleanup);
+
   it('should match the snapshot', () => {
     const renderedComponent = renderer.create(<IssueLink />).toJSON();
     expect(renderedComponent).toMatchSnapshot();
   });
 
   it('should have a className attribute', () => {
-    const renderedComponent = shallow(<IssueLink />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+    const { container } = render(<IssueLink />);
+    expect(container.firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<IssueLink id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<IssueLink id={id} />);
+    expect(container.firstChild.hasAttribute('id')).toBe(true);
+    expect(container.firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<IssueLink attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<IssueLink attribute="test" />);
+    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/containers/RepoListItem/tests/RepoLink.test.js
+++ b/app/containers/RepoListItem/tests/RepoLink.test.js
@@ -1,29 +1,32 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import RepoLink from '../RepoLink';
 
 describe('<RepoLink />', () => {
+  afterEach(cleanup);
+
   it('should match the snapshot', () => {
     const renderedComponent = renderer.create(<RepoLink />).toJSON();
     expect(renderedComponent).toMatchSnapshot();
   });
 
   it('should have a className attribute', () => {
-    const renderedComponent = shallow(<RepoLink />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+    const { container } = render(<RepoLink />);
+    expect(container.firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<RepoLink id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<RepoLink id={id} />);
+    expect(container.firstChild.hasAttribute('id')).toBe(true);
+    expect(container.firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<RepoLink attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<RepoLink attribute="test" />);
+    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/containers/RepoListItem/tests/Wrapper.test.js
+++ b/app/containers/RepoListItem/tests/Wrapper.test.js
@@ -1,27 +1,30 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
+  afterEach(cleanup);
+
   it('should render an <div> tag', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.type()).toEqual('div');
+    const { container } = render(<Wrapper />);
+    expect(container.firstChild.tagName).toEqual('DIV');
   });
 
   it('should have a className attribute', () => {
-    const renderedComponent = shallow(<Wrapper />);
-    expect(renderedComponent.prop('className')).toBeDefined();
+    const { container } = render(<Wrapper />);
+    expect(container.firstChild.hasAttribute('class')).toBe(true);
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const renderedComponent = shallow(<Wrapper id={id} />);
-    expect(renderedComponent.prop('id')).toEqual(id);
+    const { container } = render(<Wrapper id={id} />);
+    expect(container.firstChild.hasAttribute('id')).toBe(true);
+    expect(container.firstChild.id).toEqual(id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const renderedComponent = shallow(<Wrapper attribute="test" />);
-    expect(renderedComponent.prop('attribute')).toBeUndefined();
+    const { container } = render(<Wrapper attribute="test" />);
+    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
   });
 });

--- a/app/containers/RepoListItem/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/RepoListItem/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<RepoListItem /> should render a ListItem 1`] = `
+<li
+  class="Wrapper-ThVjl dVNtAR"
+>
+  <div
+    class="Item-kPuYOm jbfpqt"
+  >
+    <div
+      class="Wrapper-ThVjl hcTMtI"
+    >
+      <a
+        class="A-bJefwH kvvqog"
+        href="https://github.com/react-boilerplate/react-boilerplate"
+        target="_blank"
+      >
+        mxstbr/react-boilerplate
+      </a>
+      <a
+        class="A-bJefwH eMsNvo"
+        href="https://github.com/react-boilerplate/react-boilerplate/issues"
+        target="_blank"
+      >
+        <svg
+          class="IssueIcon-jDeGlB krkxAt"
+          height="1em"
+          width="0.875em"
+        >
+          <path
+            d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7S10.14 13.7 7 13.7 1.3 11.14 1.3 8s2.56-5.7 5.7-5.7m0-1.3C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7S10.86 1 7 1z m1 3H6v5h2V4z m0 6H6v2h2V10z"
+          />
+        </svg>
+        <span>
+          20
+        </span>
+      </a>
+    </div>
+  </div>
+</li>
+`;

--- a/app/containers/RepoListItem/tests/index.test.js
+++ b/app/containers/RepoListItem/tests/index.test.js
@@ -34,7 +34,7 @@ describe('<RepoListItem />', () => {
 
   it('should render a ListItem', () => {
     const renderedComponent = shallow(<RepoListItem item={item} />);
-    expect(renderedComponent.find(ListItem).length).toBe(1);
+    expect(renderedComponent.find(ListItem)).toHaveLength(1);
   });
 
   it('should not render the current username', () => {
@@ -65,6 +65,6 @@ describe('<RepoListItem />', () => {
 
   it('should render the IssueIcon', () => {
     const renderedComponent = renderComponent({ item });
-    expect(renderedComponent.find('svg').length).toBe(1);
+    expect(renderedComponent.find('svg')).toHaveLength(1);
   });
 });

--- a/app/containers/RepoListItem/tests/index.test.js
+++ b/app/containers/RepoListItem/tests/index.test.js
@@ -3,10 +3,9 @@
  */
 
 import React from 'react';
-import { shallow, render } from 'enzyme';
+import { cleanup, getByText, render } from 'react-testing-library';
 import { IntlProvider } from 'react-intl';
 
-import ListItem from 'components/ListItem';
 import { RepoListItem } from '../index';
 
 const renderComponent = (props = {}) =>
@@ -32,39 +31,47 @@ describe('<RepoListItem />', () => {
     };
   });
 
+  afterEach(cleanup);
+
   it('should render a ListItem', () => {
-    const renderedComponent = shallow(<RepoListItem item={item} />);
-    expect(renderedComponent.find(ListItem)).toHaveLength(1);
+    const { container } = renderComponent({ item });
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should not render the current username', () => {
-    const renderedComponent = renderComponent({
+    const { queryByText } = renderComponent({
       item,
       currentUser: item.owner.login,
     });
-    expect(renderedComponent.text()).not.toContain(item.owner.login);
+    expect(queryByText(item.owner.login)).toBeNull();
   });
 
   it('should render usernames that are not the current one', () => {
-    const renderedComponent = renderComponent({
+    const { container } = renderComponent({
       item,
       currentUser: 'nikgraf',
     });
-    expect(renderedComponent.text()).toContain(item.owner.login);
+    expect(
+      getByText(container, content => content.startsWith(item.owner.login)),
+    ).not.toBeNull();
   });
 
   it('should render the repo name', () => {
-    const renderedComponent = renderComponent({ item });
-    expect(renderedComponent.text()).toContain(item.name);
+    const { container } = renderComponent({ item });
+    expect(
+      getByText(container, content => content.endsWith(item.name)),
+    ).not.toBeNull();
   });
 
   it('should render the issue count', () => {
-    const renderedComponent = renderComponent({ item });
-    expect(renderedComponent.text()).toContain(item.open_issues_count);
+    const { container } = renderComponent({ item });
+    expect(
+      getByText(container, item.open_issues_count.toString(10)),
+    ).not.toBeNull();
   });
 
   it('should render the IssueIcon', () => {
-    const renderedComponent = renderComponent({ item });
-    expect(renderedComponent.find('svg')).toHaveLength(1);
+    const { container } = renderComponent({ item });
+    expect(container.querySelector('svg')).not.toBeNull();
   });
 });

--- a/app/index.html
+++ b/app/index.html
@@ -10,13 +10,6 @@
     <!-- Allow installing the app to the homescreen -->
     <meta name="mobile-web-app-capable" content="yes">
 
-    <!-- iOS home screen icons -->
-    <meta name="apple-mobile-web-app-title" content="react boilerplate">
-    <link rel="apple-touch-icon" sizes="120x120" href="/icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="/icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="167x167" href="/icon-167x167.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/icon-180x180.png">
-
     <link rel="icon" href="/favicon.ico" />
     <title>React.js Boilerplate</title>
   </head>

--- a/app/utils/tests/injectReducer.test.js
+++ b/app/utils/tests/injectReducer.test.js
@@ -3,9 +3,9 @@
  */
 
 import { memoryHistory } from 'react-router-dom';
-import { shallow } from 'enzyme';
 import React from 'react';
-import identity from 'lodash/identity';
+import { Provider } from 'react-redux';
+import renderer from 'react-test-renderer';
 
 import configureStore from '../../configureStore';
 import injectReducer from '../injectReducer';
@@ -14,7 +14,7 @@ import * as reducerInjectors from '../reducerInjectors';
 // Fixtures
 const Component = () => null;
 
-const reducer = identity;
+const reducer = s => s;
 
 describe('injectReducer decorator', () => {
   let store;
@@ -35,7 +35,11 @@ describe('injectReducer decorator', () => {
   });
 
   it('should inject a given reducer', () => {
-    shallow(<ComponentWithReducer />, { context: { store } });
+    renderer.create(
+      <Provider store={store}>
+        <ComponentWithReducer />
+      </Provider>,
+    );
 
     expect(injectors.injectReducer).toHaveBeenCalledTimes(1);
     expect(injectors.injectReducer).toHaveBeenCalledWith('test', reducer);
@@ -50,10 +54,15 @@ describe('injectReducer decorator', () => {
 
   it('should propagate props', () => {
     const props = { testProp: 'test' };
-    const renderedComponent = shallow(<ComponentWithReducer {...props} />, {
-      context: { store },
-    });
+    const renderedComponent = renderer.create(
+      <Provider store={store}>
+        <ComponentWithReducer {...props} />
+      </Provider>,
+    );
+    const {
+      props: { children },
+    } = renderedComponent.getInstance();
 
-    expect(renderedComponent.prop('testProp')).toBe('test');
+    expect(children.props).toEqual(props);
   });
 });

--- a/app/utils/tests/injectSaga.test.js
+++ b/app/utils/tests/injectSaga.test.js
@@ -4,8 +4,9 @@
 
 import { memoryHistory } from 'react-router-dom';
 import { put } from 'redux-saga/effects';
-import { shallow } from 'enzyme';
+import renderer from 'react-test-renderer';
 import React from 'react';
+import { Provider } from 'react-redux';
 
 import configureStore from '../../configureStore';
 import injectSaga from '../injectSaga';
@@ -43,7 +44,11 @@ describe('injectSaga decorator', () => {
 
   it('should inject given saga, mode, and props', () => {
     const props = { test: 'test' };
-    shallow(<ComponentWithSaga {...props} />, { context: { store } });
+    renderer.create(
+      <Provider store={store}>
+        <ComponentWithSaga {...props} />
+      </Provider>,
+    );
 
     expect(injectors.injectSaga).toHaveBeenCalledTimes(1);
     expect(injectors.injectSaga).toHaveBeenCalledWith(
@@ -55,9 +60,11 @@ describe('injectSaga decorator', () => {
 
   it('should eject on unmount with a correct saga key', () => {
     const props = { test: 'test' };
-    const renderedComponent = shallow(<ComponentWithSaga {...props} />, {
-      context: { store },
-    });
+    const renderedComponent = renderer.create(
+      <Provider store={store}>
+        <ComponentWithSaga {...props} />
+      </Provider>,
+    );
     renderedComponent.unmount();
 
     expect(injectors.ejectSaga).toHaveBeenCalledTimes(1);
@@ -73,10 +80,14 @@ describe('injectSaga decorator', () => {
 
   it('should propagate props', () => {
     const props = { testProp: 'test' };
-    const renderedComponent = shallow(<ComponentWithSaga {...props} />, {
-      context: { store },
-    });
-
-    expect(renderedComponent.prop('testProp')).toBe('test');
+    const renderedComponent = renderer.create(
+      <Provider store={store}>
+        <ComponentWithSaga {...props} />
+      </Provider>,
+    );
+    const {
+      props: { children },
+    } = renderedComponent.getInstance();
+    expect(children.props).toEqual(props);
   });
 });

--- a/docs/general/components.md
+++ b/docs/general/components.md
@@ -7,7 +7,7 @@ Since all the files kept in the same folder, this should be a breeze.
 ## When?
 
 Often when working on a project, you find you've created a component that you
-could use is other upcoming projects. You would like to extract that
+could use in other upcoming projects. You would like to extract that
 component to its own git repository and npm package since keeping the version
 histories separate makes a lot of sense.
 

--- a/internals/generators/component/test.js.hbs
+++ b/internals/generators/component/test.js.hbs
@@ -1,9 +1,11 @@
 // import React from 'react';
-// import { shallow } from 'enzyme';
+// import { cleanup, render } from 'react-testing-library';
 
 // import {{ properCase name }} from '../index';
 
 describe('<{{ properCase name }} />', () => {
+  // afterEach(cleanup);
+
   it('Expect to have unit tests specified', () => {
     expect(true).toEqual(false);
   });

--- a/internals/generators/container/test.js.hbs
+++ b/internals/generators/container/test.js.hbs
@@ -1,9 +1,11 @@
 // import React from 'react';
-// import { shallow } from 'enzyme';
+// import { cleanup, render } from 'react-testing-library';
 
 // import { {{ properCase name }} } from '../index';
 
 describe('<{{ properCase name }} />', () => {
+  // afterEach(cleanup);
+
   it('Expect to have unit tests specified', () => {
     expect(true).toEqual(false);
   });

--- a/internals/scripts/npmcheckversion.js
+++ b/internals/scripts/npmcheckversion.js
@@ -1,8 +1,8 @@
-const exec = require('child_process').exec;
-exec('npm -v', function(err, stdout, stderr) {
+const { exec } = require('child_process');
+exec('npm -v', (err, stdout) => {
   if (err) throw err;
-  if (parseFloat(stdout) < 3) {
-    throw new Error('[ERROR: React Boilerplate] You need npm version @>=3');
-    process.exit(1);
+  if (parseFloat(stdout) < 5) {
+    throw new Error('[ERROR: React Boilerplate] You need npm version @>=5');
+    // process.exit(1);
   }
 });

--- a/internals/scripts/setup.js
+++ b/internals/scripts/setup.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-'use strict';
+
 
 const shell = require('shelljs');
 const exec = require('child_process').exec;
@@ -21,7 +21,7 @@ cleanRepo(() => {
   process.stdout.write(
     '\nInstalling dependencies... (This might take a while)',
   );
-  setTimeout(function() {
+  setTimeout(() => {
     readline.cursorTo(process.stdout, 0);
     interval = animateProgress('Installing dependencies');
   }, 500);
@@ -35,7 +35,7 @@ cleanRepo(() => {
 function cleanRepo(callback) {
   fs.readFile('.git/config', 'utf8', (err, data) => {
     if (!err) {
-      let isClonedRepo =
+      const isClonedRepo =
         typeof data === 'string' &&
         (data.match(/url\s*=/g) || []).length === 1 &&
         /react-boilerplate\/react-boilerplate\.git/.test(data);
@@ -43,7 +43,7 @@ function cleanRepo(callback) {
         process.stdout.write('\nDo you want to clear old repository? [Y/n] ');
         process.stdin.resume();
         process.stdin.on('data', data => {
-          let val = data.toString().trim();
+          const val = data.toString().trim();
           if (val === 'y' || val === 'Y' || val === '') {
             process.stdout.write('Removing old repository');
             shell.rm('-rf', '.git/');
@@ -66,7 +66,7 @@ function cleanRepo(callback) {
  */
 function dontClearRepo(nl, callback) {
   clearRepo = false;
-  process.stdout.write(nl + 'Leaving your repository untouched');
+  process.stdout.write(`${nl  }Leaving your repository untouched`);
   addCheckMark(callback);
 }
 
@@ -91,15 +91,15 @@ function deleteFileInCurrentDir(file, callback) {
  * Installs dependencies
  */
 function installDeps() {
-  exec('node --version', function(err, stdout, stderr) {
+  exec('node --version', (err, stdout, stderr) => {
     const nodeVersion = stdout && parseFloat(stdout.substring(1));
     if (nodeVersion < 5 || err) {
       installDepsCallback(
         err ||
-          'Unsupported node.js version, make sure you have the latest version installed.',
+        'Unsupported node.js version, make sure you have the latest version installed.',
       );
     } else {
-      exec('yarn --version', function(err, stdout, stderr) {
+      exec('yarn --version', function (err, stdout, stderr) {
         if (
           parseFloat(stdout) < 0.15 ||
           err ||
@@ -126,11 +126,11 @@ function installDepsCallback(error) {
     process.exit(1);
   }
 
-  deleteFileInCurrentDir('setup.js', function() {
+  deleteFileInCurrentDir('setup.js', () => {
     if (clearRepo) {
       interval = animateProgress('Initialising new repository');
       process.stdout.write('Initialising new repository');
-      initGit(function() {
+      initGit(function () {
         clearInterval(interval);
         endProcess();
       });

--- a/internals/templates/containers/App/tests/__snapshots__/index.test.js.snap
+++ b/internals/templates/containers/App/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<App /> should render and match the snapshot 1`] = `
+<div>
+  <Switch>
+    <Route
+      component={[Function]}
+      exact={true}
+      path="/"
+    />
+    <Route
+      component={[Function]}
+    />
+  </Switch>
+</div>
+`;

--- a/internals/templates/containers/App/tests/index.test.js
+++ b/internals/templates/containers/App/tests/index.test.js
@@ -1,12 +1,14 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { Route } from 'react-router-dom';
+import ShallowRenderer from 'react-test-renderer/shallow';
 
 import App from '../index';
 
+const renderer = new ShallowRenderer();
+
 describe('<App />', () => {
-  it('should render some routes', () => {
-    const renderedComponent = shallow(<App />);
-    expect(renderedComponent.find(Route).length).not.toBe(0);
+  it('should render and match the snapshot', () => {
+    renderer.render(<App />);
+    const renderedOutput = renderer.getRenderOutput();
+    expect(renderedOutput).toMatchSnapshot();
   });
 });

--- a/internals/templates/containers/HomePage/tests/__snapshots__/index.test.js.snap
+++ b/internals/templates/containers/HomePage/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<HomePage /> should render and match the snapshot 1`] = `
+<h1>
+  <span>
+    This is HomePage component!
+  </span>
+</h1>
+`;

--- a/internals/templates/containers/HomePage/tests/index.test.js
+++ b/internals/templates/containers/HomePage/tests/index.test.js
@@ -1,15 +1,20 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
+import { IntlProvider } from 'react-intl';
 
 import HomePage from '../index';
-import messages from '../messages';
 
 describe('<HomePage />', () => {
-  it('should render the page message', () => {
-    const renderedComponent = shallow(<HomePage />);
-    expect(
-      renderedComponent.contains(<FormattedMessage {...messages.header} />),
-    ).toEqual(true);
+  afterEach(cleanup);
+
+  it('should render and match the snapshot', () => {
+    const {
+      container: { firstChild },
+    } = render(
+      <IntlProvider locale="en">
+        <HomePage />
+      </IntlProvider>,
+    );
+    expect(firstChild).toMatchSnapshot();
   });
 });

--- a/internals/templates/containers/NotFoundPage/tests/__snapshots__/index.test.js.snap
+++ b/internals/templates/containers/NotFoundPage/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<NotFoundPage /> should render and match the snapshot 1`] = `
+<h1>
+  <span>
+    This is NotFoundPage component!
+  </span>
+</h1>
+`;

--- a/internals/templates/containers/NotFoundPage/tests/index.test.js
+++ b/internals/templates/containers/NotFoundPage/tests/index.test.js
@@ -1,15 +1,20 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
-import { shallow } from 'enzyme';
+import { cleanup, render } from 'react-testing-library';
+import { IntlProvider } from 'react-intl';
 
 import NotFoundPage from '../index';
-import messages from '../messages';
 
 describe('<NotFoundPage />', () => {
-  it('should render the page message', () => {
-    const renderedComponent = shallow(<NotFoundPage />);
-    expect(
-      renderedComponent.contains(<FormattedMessage {...messages.header} />),
-    ).toEqual(true);
+  afterEach(cleanup);
+
+  it('should render and match the snapshot', () => {
+    const {
+      container: { firstChild },
+    } = render(
+      <IntlProvider locale="en">
+        <NotFoundPage />
+      </IntlProvider>,
+    );
+    expect(firstChild).toMatchSnapshot();
   });
 });

--- a/internals/templates/utils/tests/injectReducer.test.js
+++ b/internals/templates/utils/tests/injectReducer.test.js
@@ -3,9 +3,9 @@
  */
 
 import { memoryHistory } from 'react-router-dom';
-import { shallow } from 'enzyme';
 import React from 'react';
-import identity from 'lodash/identity';
+import { Provider } from 'react-redux';
+import renderer from 'react-test-renderer';
 
 import configureStore from '../../configureStore';
 import injectReducer from '../injectReducer';
@@ -14,7 +14,7 @@ import * as reducerInjectors from '../reducerInjectors';
 // Fixtures
 const Component = () => null;
 
-const reducer = identity;
+const reducer = s => s;
 
 describe('injectReducer decorator', () => {
   let store;
@@ -35,7 +35,11 @@ describe('injectReducer decorator', () => {
   });
 
   it('should inject a given reducer', () => {
-    shallow(<ComponentWithReducer />, { context: { store } });
+    renderer.create(
+      <Provider store={store}>
+        <ComponentWithReducer />
+      </Provider>,
+    );
 
     expect(injectors.injectReducer).toHaveBeenCalledTimes(1);
     expect(injectors.injectReducer).toHaveBeenCalledWith('test', reducer);
@@ -50,10 +54,15 @@ describe('injectReducer decorator', () => {
 
   it('should propagate props', () => {
     const props = { testProp: 'test' };
-    const renderedComponent = shallow(<ComponentWithReducer {...props} />, {
-      context: { store },
-    });
+    const renderedComponent = renderer.create(
+      <Provider store={store}>
+        <ComponentWithReducer {...props} />
+      </Provider>,
+    );
+    const {
+      props: { children },
+    } = renderedComponent.getInstance();
 
-    expect(renderedComponent.prop('testProp')).toBe('test');
+    expect(children.props).toEqual(props);
   });
 });

--- a/internals/templates/utils/tests/injectSaga.test.js
+++ b/internals/templates/utils/tests/injectSaga.test.js
@@ -4,8 +4,9 @@
 
 import { memoryHistory } from 'react-router-dom';
 import { put } from 'redux-saga/effects';
-import { shallow } from 'enzyme';
+import renderer from 'react-test-renderer';
 import React from 'react';
+import { Provider } from 'react-redux';
 
 import configureStore from '../../configureStore';
 import injectSaga from '../injectSaga';
@@ -43,7 +44,11 @@ describe('injectSaga decorator', () => {
 
   it('should inject given saga, mode, and props', () => {
     const props = { test: 'test' };
-    shallow(<ComponentWithSaga {...props} />, { context: { store } });
+    renderer.create(
+      <Provider store={store}>
+        <ComponentWithSaga {...props} />
+      </Provider>,
+    );
 
     expect(injectors.injectSaga).toHaveBeenCalledTimes(1);
     expect(injectors.injectSaga).toHaveBeenCalledWith(
@@ -55,9 +60,11 @@ describe('injectSaga decorator', () => {
 
   it('should eject on unmount with a correct saga key', () => {
     const props = { test: 'test' };
-    const renderedComponent = shallow(<ComponentWithSaga {...props} />, {
-      context: { store },
-    });
+    const renderedComponent = renderer.create(
+      <Provider store={store}>
+        <ComponentWithSaga {...props} />
+      </Provider>,
+    );
     renderedComponent.unmount();
 
     expect(injectors.ejectSaga).toHaveBeenCalledTimes(1);
@@ -73,10 +80,14 @@ describe('injectSaga decorator', () => {
 
   it('should propagate props', () => {
     const props = { testProp: 'test' };
-    const renderedComponent = shallow(<ComponentWithSaga {...props} />, {
-      context: { store },
-    });
-
-    expect(renderedComponent.prop('testProp')).toBe('test');
+    const renderedComponent = renderer.create(
+      <Provider store={store}>
+        <ComponentWithSaga {...props} />
+      </Provider>,
+    );
+    const {
+      props: { children },
+    } = renderedComponent.getInstance();
+    expect(children.props).toEqual(props);
   });
 });

--- a/internals/testing/enzyme-setup.js
+++ b/internals/testing/enzyme-setup.js
@@ -1,4 +1,0 @@
-import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
-configure({ adapter: new Adapter() });

--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -75,10 +75,17 @@ module.exports = require('./webpack.base.babel')({
       description: 'My React Boilerplate-based project!',
       background_color: '#fafafa',
       theme_color: '#b1624d',
+      inject: true,
+      ios: true,
       icons: [
         {
           src: path.resolve('app/images/icon-512x512.png'),
-          sizes: [72, 96, 120, 128, 144, 152, 167, 180, 192, 384, 512],
+          sizes: [72, 96, 128, 144, 192, 384, 512],
+        },
+        {
+          src: path.resolve('app/images/icon-512x512.png'),
+          sizes: [120, 152, 167, 180],
+          ios: true,
         },
       ],
     }),

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "engines": {
     "npm": ">=5",
-    "node": ">=8"
+    "node": ">=8.10.0"
   },
   "author": "Max Stoiber",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -135,13 +135,10 @@
     },
     "setupTestFrameworkScriptFile": "<rootDir>/internals/testing/test-bundler.js",
     "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/internals/testing/enzyme-setup.js"
+      "raf/polyfill"
     ],
     "testRegex": "tests/.*\\.test\\.js$",
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ]
+    "snapshotSerializers": []
   },
   "dependencies": {
     "babel-polyfill": "6.26.0",
@@ -197,9 +194,6 @@
     "circular-dependency-plugin": "5.0.2",
     "coveralls": "3.0.1",
     "css-loader": "0.28.11",
-    "enzyme": "3.3.0",
-    "enzyme-adapter-react-16": "1.1.1",
-    "enzyme-to-json": "3.3.4",
     "eslint": "4.19.1",
     "eslint-config-airbnb": "16.1.0",
     "eslint-config-airbnb-base": "12.1.0",
@@ -219,6 +213,7 @@
     "image-webpack-loader": "4.3.1",
     "imports-loader": "0.8.0",
     "jest-cli": "23.1.0",
+    "jest-dom": "1.7.0",
     "jest-styled-components": "5.0.1",
     "lint-staged": "7.2.0",
     "ngrok": "3.0.1",
@@ -228,7 +223,9 @@
     "plop": "2.0.0",
     "pre-commit": "1.2.2",
     "prettier": "1.13.5",
+    "raf": "3.4.0",
     "react-test-renderer": "16.4.1",
+    "react-testing-library": "4.1.2",
     "rimraf": "2.6.2",
     "shelljs": "0.8.2",
     "style-loader": "0.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,10 +181,6 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@types/node@*":
-  version "10.3.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.4.tgz#c74e8aec19e555df44609b8057311052a2c84d9e"
-
 "@types/node@^8.0.19":
   version "8.10.20"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.20.tgz#fe674ea52e13950ab10954433a7824438aabbcac"
@@ -2072,17 +2068,6 @@ chardet@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.5.0.tgz#fe3ac73c00c3d865ffcc02a0682e2c20b6a06029"
 
-cheerio@^1.0.0-rc.2:
-  version "1.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
-  dependencies:
-    css-select "~1.2.0"
-    dom-serializer "~0.1.0"
-    entities "~1.1.1"
-    htmlparser2 "^3.9.1"
-    lodash "^4.15.0"
-    parse5 "^3.0.1"
-
 chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -2303,10 +2288,6 @@ colormin@^1.0.5:
     color "^0.11.0"
     css-color-names "0.0.4"
     has "^1.0.1"
-
-colors@0.5.x:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
 colors@^1.1.2:
   version "1.3.0"
@@ -2586,7 +2567,7 @@ css-select-base-adapter@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.0.tgz#0102b3d14630df86c3eb9fa9f5456270106cf990"
 
-css-select@^1.1.0, css-select@~1.2.0:
+css-select@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
   dependencies:
@@ -2642,7 +2623,7 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
-css@^2.2.1:
+css@^2.2.1, css@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.3.tgz#f861f4ba61e79bedc962aa548e5780fd95cbc6be"
   dependencies:
@@ -3065,10 +3046,6 @@ dir-glob@^2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
-discontinuous-range@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
-
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -3088,12 +3065,21 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-serializer@0, dom-serializer@~0.1.0:
+dom-serializer@0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   dependencies:
     domelementtype "~1.1.1"
     entities "~1.1.1"
+
+dom-testing-library@^2.6.0:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-2.9.1.tgz#813eff283b2fd97649b1382817636547329b2409"
+  dependencies:
+    jest-dom "^1.0.0"
+    mutationobserver-shim "^0.3.2"
+    pretty-format "^22.4.3"
+    wait-for-expect "^0.4.0"
 
 dom-walk@^0.1.0:
   version "0.1.1"
@@ -3306,53 +3292,6 @@ enhanced-resolve@~0.9.0:
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
-
-enzyme-adapter-react-16@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz#a8f4278b47e082fbca14f5bfb1ee50ee650717b4"
-  dependencies:
-    enzyme-adapter-utils "^1.3.0"
-    lodash "^4.17.4"
-    object.assign "^4.0.4"
-    object.values "^1.0.4"
-    prop-types "^15.6.0"
-    react-reconciler "^0.7.0"
-    react-test-renderer "^16.0.0-0"
-
-enzyme-adapter-utils@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz#d6c85756826c257a8544d362cc7a67e97ea698c7"
-  dependencies:
-    lodash "^4.17.4"
-    object.assign "^4.0.4"
-    prop-types "^15.6.0"
-
-enzyme-to-json@3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.4.tgz#67c6040e931182f183418af2eb9f4323258aa77f"
-  dependencies:
-    lodash "^4.17.4"
-
-enzyme@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"
-  dependencies:
-    cheerio "^1.0.0-rc.2"
-    function.prototype.name "^1.0.3"
-    has "^1.0.1"
-    is-boolean-object "^1.0.0"
-    is-callable "^1.1.3"
-    is-number-object "^1.0.3"
-    is-string "^1.0.4"
-    is-subset "^0.1.1"
-    lodash "^4.17.4"
-    object-inspect "^1.5.0"
-    object-is "^1.0.1"
-    object.assign "^4.1.0"
-    object.entries "^1.0.4"
-    object.values "^1.0.4"
-    raf "^3.4.0"
-    rst-selector-parser "^2.2.3"
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -4264,14 +4203,6 @@ function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
-function.prototype.name@^1.0.3:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz#8bd763cc0af860a859cc5d49384d74b932cd2327"
-  dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    is-callable "^1.1.3"
-
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
@@ -4805,7 +4736,7 @@ html-webpack-plugin@3.2.0:
     toposort "^1.0.0"
     util.promisify "1.0.0"
 
-htmlparser2@^3.9.1, htmlparser2@^3.9.2:
+htmlparser2@^3.9.2:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   dependencies:
@@ -5197,10 +5128,6 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-boolean-object@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
-
 is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -5371,10 +5298,6 @@ is-natural-number@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
 
-is-number-object@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
-
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -5488,14 +5411,6 @@ is-retry-allowed@^1.0.0:
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-
-is-string@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
-
-is-subset@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
 
 is-supported-regexp-flag@^1.0.0:
   version "1.0.1"
@@ -5731,6 +5646,15 @@ jest-config@^23.1.0:
     jest-validate "^23.0.1"
     pretty-format "^23.0.1"
 
+jest-diff@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-22.4.3.tgz#e18cc3feff0aeef159d02310f2686d4065378030"
+  dependencies:
+    chalk "^2.0.1"
+    diff "^3.2.0"
+    jest-get-type "^22.4.3"
+    pretty-format "^22.4.3"
+
 jest-diff@^23.0.1:
   version "23.0.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.0.1.tgz#3d49137cee12c320a4b4d2b4a6fa6e82d491a16a"
@@ -5749,6 +5673,28 @@ jest-docblock@^23.0.1:
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.0.1.tgz#deddd18333be5dc2415260a04ef3fce9276b5725"
   dependencies:
     detect-newline "^2.1.0"
+
+jest-dom@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-1.7.0.tgz#72aa40a27aafde2967d8ce6e8d20022ad59922d6"
+  dependencies:
+    chalk "^2.4.1"
+    css "^2.2.3"
+    jest-diff "^22.4.3"
+    jest-matcher-utils "^22.4.3"
+    pretty-format "^23.0.1"
+    redent "^2.0.0"
+
+jest-dom@^1.0.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-1.10.0.tgz#656b609ad8ee5106459fccb425f8081b13a3a49e"
+  dependencies:
+    chalk "^2.4.1"
+    css "^2.2.3"
+    jest-diff "^22.4.3"
+    jest-matcher-utils "^22.4.3"
+    pretty-format "^23.0.1"
+    redent "^2.0.0"
 
 jest-each@^23.1.0:
   version "23.1.0"
@@ -5772,7 +5718,7 @@ jest-environment-node@^23.1.0:
     jest-mock "^23.1.0"
     jest-util "^23.1.0"
 
-jest-get-type@^22.1.0:
+jest-get-type@^22.1.0, jest-get-type@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
 
@@ -5809,6 +5755,14 @@ jest-leak-detector@^23.0.1:
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.0.1.tgz#9dba07505ac3495c39d3ec09ac1e564599e861a0"
   dependencies:
     pretty-format "^23.0.1"
+
+jest-matcher-utils@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz#4632fe428ebc73ebc194d3c7b65d37b161f710ff"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.4.3"
+    pretty-format "^22.4.3"
 
 jest-matcher-utils@^23.0.1:
   version "23.0.1"
@@ -6383,10 +6337,6 @@ lodash.escape@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash.flattendeep@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
-
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -6448,7 +6398,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.17.10, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
+lodash@4.17.10, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -6888,6 +6838,10 @@ multipipe@^0.1.2:
   dependencies:
     duplexer2 "0.0.2"
 
+mutationobserver-shim@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#f4d5dae7a4971a2207914fb5a90ebd514b65acca"
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
@@ -6916,15 +6870,6 @@ nanomatch@^1.2.9:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
-
-nearley@^2.7.10:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.13.0.tgz#6e7b0f4e68bfc3e74c99eaef2eda39e513143439"
-  dependencies:
-    nomnom "~1.6.2"
-    railroad-diagrams "^1.0.0"
-    randexp "0.4.6"
-    semver "^5.4.1"
 
 needle@^2.2.0:
   version "2.2.1"
@@ -7067,13 +7012,6 @@ node-pre-gyp@^0.10.0:
 node-status-codes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
-
-nomnom@~1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
-  dependencies:
-    colors "0.5.x"
-    underscore "~1.4.4"
 
 nopt@^3.0.1:
   version "3.0.6"
@@ -7223,14 +7161,6 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
-
-object-is@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
-
 object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
@@ -7241,7 +7171,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.0.4, object.assign@^4.1.0:
+object.assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
   dependencies:
@@ -7258,15 +7188,6 @@ object.defaults@^1.1.0:
     array-slice "^1.0.0"
     for-own "^1.0.0"
     isobject "^3.0.0"
-
-object.entries@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.6.1"
-    function-bind "^1.1.0"
-    has "^1.0.1"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
@@ -7583,12 +7504,6 @@ parse-passwd@^1.0.0:
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
-
-parse5@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
-  dependencies:
-    "@types/node" "*"
 
 parseurl@~1.3.2:
   version "1.3.2"
@@ -8124,6 +8039,13 @@ pretty-error@^2.0.2:
     renderkid "^2.0.1"
     utila "~0.4"
 
+pretty-format@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
 pretty-format@^23.0.1:
   version "23.0.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.0.1.tgz#d61d065268e4c759083bccbca27a01ad7c7601f4"
@@ -8260,22 +8182,11 @@ quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
 
-raf@^3.4.0:
+raf@3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
   dependencies:
     performance-now "^2.1.0"
-
-railroad-diagrams@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
-
-randexp@0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
-  dependencies:
-    discontinuous-range "1.0.0"
-    ret "~0.1.10"
 
 randomatic@^3.0.0:
   version "3.0.0"
@@ -8357,15 +8268,6 @@ react-loadable@5.4.0:
   dependencies:
     prop-types "^15.5.0"
 
-react-reconciler@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 react-redux@5.0.7:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.7.tgz#0dc1076d9afb4670f993ffaef44b8f8c1155a4c8"
@@ -8415,7 +8317,7 @@ react-side-effect@^1.1.0:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
-react-test-renderer@16.4.1, react-test-renderer@^16.0.0-0:
+react-test-renderer@16.4.1:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.4.1.tgz#f2fb30c2c7b517db6e5b10ed20bb6b0a7ccd8d70"
   dependencies:
@@ -8423,6 +8325,13 @@ react-test-renderer@16.4.1, react-test-renderer@^16.0.0-0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
     react-is "^16.4.1"
+
+react-testing-library@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-4.1.2.tgz#20f9ea975c1f272b14f52bcc8e16e267382ea17f"
+  dependencies:
+    dom-testing-library "^2.6.0"
+    wait-for-expect "^1.0.0"
 
 react@16.4.1:
   version "16.4.1"
@@ -8879,13 +8788,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
-
-rst-selector-parser@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
-  dependencies:
-    lodash.flattendeep "^4.4.0"
-    nearley "^2.7.10"
 
 rsvp@^3.3.3:
   version "3.6.2"
@@ -10057,10 +9959,6 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
 
-underscore@~1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
-
 unherit@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.1.tgz#132748da3e88eab767e08fabfbb89c5e9d28628c"
@@ -10401,6 +10299,14 @@ w3c-hr-time@^1.0.1:
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
   dependencies:
     browser-process-hrtime "^0.1.2"
+
+wait-for-expect@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-0.4.0.tgz#341c96ab89d6102a0169a9be6cd0de354de92c17"
+
+wait-for-expect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.0.0.tgz#edf2d5790c36dc67c4e21ac6ccedd7d4b79dc6ac"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
## React Boilerplate

### Proof of Concept

#### Replacing Enzyme with react-testing-library

As I am not that happy with Enzyme and there is yet no complete React 16 support I thought "Hey, let's give [react-testing-library](https://github.com/kentcdodds/react-testing-library)' a try, heard good things about it". And I have to say, I really like it.
I like for example that you can use normal DOM selectors because tests work with actual DOM nodes. This makes it also that tests are closer to the 'real' world. It has, hardly, any learning costs and does not require any setup.

It proofed its point already in the case of ```containers/RepoListItem/IssueIcon``` that decorates ```components/IssueIcon```.
One of the test cases for ```containers/RepoListItem/IssueIcon``` state that it 'should adopt any attribute'. This test passed by checking the ```props``` with Enzyme so, yes, the property exists in ```props``` but ```components/IssueIcon``` did not pass them.

For me it's a keeper. Please tell me your thoughts

[react-testing-library](https://github.com/kentcdodds/react-testing-library)