### PR TITLE
Changing to use current and LTS versions for testing; should remove t…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
-  - 9
-  - 8
+  - "node"
+  - "lts/*"
 
 script:
   - node ./internals/scripts/generate-templates-for-linting

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ environment:
 
   matrix:
     # Node versions to run
-    - nodejs_version: 9
-    - nodejs_version: 8
+    - nodejs_version: Current
+    - nodejs_version: LTS
 
 # Fix line endings in Windows. (runs before repo cloning)
 init:


### PR DESCRIPTION
Changing to use current and LTS versions for testing. Should remove the need to update every time a new node major version comes out or an LTS is EoL.
