### PR TITLE
feat(i18n): Readded: Use namespaced variables in message paths

### DIFF
--- a/app/components/Footer/messages.js
+++ b/app/components/Footer/messages.js
@@ -5,13 +5,15 @@
  */
 import { defineMessages } from 'react-intl';
 
+export const scope = 'boilerplate.components.Footer';
+
 export default defineMessages({
   licenseMessage: {
-    id: 'boilerplate.components.Footer.license.message',
+    id: `${scope}.license.message`,
     defaultMessage: 'This project is licensed under the MIT license.',
   },
   authorMessage: {
-    id: 'boilerplate.components.Footer.author.message',
+    id: `${scope}.author.message`,
     defaultMessage: `
       Made with love by {author}.
     `,

--- a/app/components/Header/messages.js
+++ b/app/components/Header/messages.js
@@ -5,13 +5,15 @@
  */
 import { defineMessages } from 'react-intl';
 
+export const scope = 'boilerplate.components.Header';
+
 export default defineMessages({
   home: {
-    id: 'boilerplate.components.Header.home',
+    id: `${scope}.home`,
     defaultMessage: 'Home',
   },
   features: {
-    id: 'boilerplate.components.Header.features',
+    id: `${scope}.features`,
     defaultMessage: 'Features',
   },
 });

--- a/app/containers/FeaturePage/messages.js
+++ b/app/containers/FeaturePage/messages.js
@@ -5,26 +5,28 @@
  */
 import { defineMessages } from 'react-intl';
 
+export const scope = 'boilerplate.containers.FeaturePage';
+
 export default defineMessages({
   header: {
-    id: 'boilerplate.containers.FeaturePage.header',
+    id: `${scope}.header`,
     defaultMessage: 'Features',
   },
   scaffoldingHeader: {
-    id: 'boilerplate.containers.FeaturePage.scaffolding.header',
+    id: `${scope}.scaffolding.header`,
     defaultMessage: 'Quick scaffolding',
   },
   scaffoldingMessage: {
-    id: 'boilerplate.containers.FeaturePage.scaffolding.message',
+    id: `${scope}.scaffolding.message`,
     defaultMessage: `Automate the creation of components, containers, routes, selectors
   and sagas - and their tests - right from the CLI!`,
   },
   feedbackHeader: {
-    id: 'boilerplate.containers.FeaturePage.feedback.header',
+    id: `${scope}.feedback.header`,
     defaultMessage: 'Instant feedback',
   },
   feedbackMessage: {
-    id: 'boilerplate.containers.FeaturePage.feedback.message',
+    id: `${scope}.feedback.message`,
     defaultMessage: `
       Enjoy the best DX and code your app at the speed of thought! Your
     saved changes to the CSS and JS are reflected instantaneously
@@ -33,39 +35,39 @@ export default defineMessages({
     `,
   },
   stateManagementHeader: {
-    id: 'boilerplate.containers.FeaturePage.state_management.header',
+    id: `${scope}.state_management.header`,
     defaultMessage: 'Predictable state management',
   },
   stateManagementMessages: {
-    id: 'boilerplate.containers.FeaturePage.state_management.message',
+    id: `${scope}.state_management.message`,
     defaultMessage: `
       Unidirectional data flow allows for change logging and time travel
     debugging.
     `,
   },
   javascriptHeader: {
-    id: 'boilerplate.containers.FeaturePage.javascript.header',
+    id: `${scope}.javascript.header`,
     defaultMessage: 'Next generation JavaScript',
   },
   javascriptMessage: {
-    id: 'boilerplate.containers.FeaturePage.javascript.message',
+    id: `${scope}.javascript.message`,
     defaultMessage: `Use template strings, object destructuring, arrow functions, JSX
     syntax and more, today.`,
   },
   cssHeader: {
-    id: 'boilerplate.containers.FeaturePage.css.header',
+    id: `${scope}.css.header`,
     defaultMessage: 'Features',
   },
   cssMessage: {
-    id: 'boilerplate.containers.FeaturePage.css.message',
+    id: `${scope}.css.message`,
     defaultMessage: 'Next generation CSS',
   },
   routingHeader: {
-    id: 'boilerplate.containers.FeaturePage.routing.header',
+    id: `${scope}.routing.header`,
     defaultMessage: 'Industry-standard routing',
   },
   routingMessage: {
-    id: 'boilerplate.containers.FeaturePage.routing.message',
+    id: `${scope}.routing.message`,
     defaultMessage: `
       Write composable CSS that's co-located with your components for
     complete modularity. Unique generated class names keep the
@@ -74,23 +76,23 @@ export default defineMessages({
     `,
   },
   networkHeader: {
-    id: 'boilerplate.containers.FeaturePage.network.header',
+    id: `${scope}.network.header`,
     defaultMessage: 'Offline-first',
   },
   networkMessage: {
-    id: 'boilerplate.containers.FeaturePage.network.message',
+    id: `${scope}.network.message`,
     defaultMessage: `
       The next frontier in performant web apps: availability without a
       network connection from the instant your users load the app.
     `,
   },
   intlHeader: {
-    id: 'boilerplate.containers.FeaturePage.internationalization.header',
+    id: `${scope}.internationalization.header`,
     defaultMessage:
       'Complete i18n Standard Internationalization & Pluralization',
   },
   intlMessage: {
-    id: 'boilerplate.containers.FeaturePage.internationalization.message',
+    id: `${scope}.internationalization.message`,
     defaultMessage:
       'Scalable apps need to support multiple languages, easily add and support multiple languages with `react-intl`.',
   },

--- a/app/containers/HomePage/messages.js
+++ b/app/containers/HomePage/messages.js
@@ -5,26 +5,28 @@
  */
 import { defineMessages } from 'react-intl';
 
+export const scope = 'boilerplate.containers.HomePage';
+
 export default defineMessages({
   startProjectHeader: {
-    id: 'boilerplate.containers.HomePage.start_project.header',
+    id: `${scope}.start_project.header`,
     defaultMessage: 'Start your next react project in seconds',
   },
   startProjectMessage: {
-    id: 'boilerplate.containers.HomePage.start_project.message',
+    id: `${scope}.start_project.message`,
     defaultMessage:
       'A highly scalable, offline-first foundation with the best DX and a focus on performance and best practices',
   },
   trymeHeader: {
-    id: 'boilerplate.containers.HomePage.tryme.header',
+    id: `${scope}.tryme.header`,
     defaultMessage: 'Try me!',
   },
   trymeMessage: {
-    id: 'boilerplate.containers.HomePage.tryme.message',
+    id: `${scope}.tryme.message`,
     defaultMessage: 'Show Github repositories by',
   },
   trymeAtPrefix: {
-    id: 'boilerplate.containers.HomePage.tryme.atPrefix',
+    id: `${scope}.tryme.atPrefix`,
     defaultMessage: '@',
   },
 });

--- a/app/containers/LocaleToggle/messages.js
+++ b/app/containers/LocaleToggle/messages.js
@@ -5,13 +5,15 @@
  */
 import { defineMessages } from 'react-intl';
 
+export const scope = 'boilerplate.containers.LocaleToggle';
+
 export default defineMessages({
   en: {
-    id: 'boilerplate.containers.LocaleToggle.en',
+    id: `${scope}.en`,
     defaultMessage: 'en',
   },
   de: {
-    id: 'boilerplate.containers.LocaleToggle.de',
+    id: `${scope}.de`,
     defaultMessage: 'de',
   },
 });

--- a/app/containers/NotFoundPage/messages.js
+++ b/app/containers/NotFoundPage/messages.js
@@ -5,9 +5,11 @@
  */
 import { defineMessages } from 'react-intl';
 
+export const scope = 'boilerplate.containers.NotFoundPage';
+
 export default defineMessages({
   header: {
-    id: 'boilerplate.containers.NotFoundPage.header',
+    id: `${scope}.header`,
     defaultMessage: 'Page not found.',
   },
 });

--- a/docs/js/i18n.md
+++ b/docs/js/i18n.md
@@ -25,13 +25,15 @@ https://github.com/yahoo/react-intl/wiki/API#definemessages
  */
 import { defineMessages } from 'react-intl';
 
+export const scope = 'boilerplate.components.Footer';
+
 export default defineMessages({
   licenseMessage: {
-    id: 'boilerplate.components.Footer.license.message',
+    id: `${scope}.license.message`, // equals 'boilerplate.components.Footer.license.message'
     defaultMessage: 'This project is licensed under the MIT license.',
   },
   authorMessage: {
-    id: 'boilerplate.components.Footer.author.message',
+    id: `${scope}.author.message`,
     defaultMessage: `
       Made with love by {author}.
     `,

--- a/internals/generators/component/messages.js.hbs
+++ b/internals/generators/component/messages.js.hbs
@@ -6,9 +6,11 @@
 
 import { defineMessages } from 'react-intl';
 
+export const scope = 'app.components.{{ properCase name }}';
+
 export default defineMessages({
   header: {
-    id: 'app.components.{{ properCase name }}.header',
-    defaultMessage: 'This is the {{ properCase name}} component !',
+    id: `${scope}.header`,
+    defaultMessage: 'This is the {{ properCase name }} component!',
   },
 });

--- a/internals/generators/container/messages.js.hbs
+++ b/internals/generators/container/messages.js.hbs
@@ -1,14 +1,16 @@
 /*
- * {{properCase name }} Messages
+ * {{ properCase name }} Messages
  *
- * This contains all the text for the {{properCase name }} component.
+ * This contains all the text for the {{ properCase name }} container.
  */
 
 import { defineMessages } from 'react-intl';
 
+export const scope = 'app.containers.{{ properCase name }}';
+
 export default defineMessages({
   header: {
-    id: 'app.containers.{{properCase name }}.header',
-    defaultMessage: 'This is {{properCase name}} container !',
+    id: `${scope}.header`,
+    defaultMessage: 'This is the {{ properCase name }} container!',
   },
 });

--- a/internals/templates/containers/HomePage/messages.js
+++ b/internals/templates/containers/HomePage/messages.js
@@ -1,13 +1,15 @@
 /*
  * HomePage Messages
  *
- * This contains all the text for the HomePage component.
+ * This contains all the text for the HomePage container.
  */
 import { defineMessages } from 'react-intl';
 
+export const scope = 'app.containers.HomePage';
+
 export default defineMessages({
   header: {
-    id: 'app.components.HomePage.header',
-    defaultMessage: 'This is HomePage component!',
+    id: `${scope}.header`,
+    defaultMessage: 'This is the HomePage container!',
   },
 });

--- a/internals/templates/containers/NotFoundPage/messages.js
+++ b/internals/templates/containers/NotFoundPage/messages.js
@@ -1,13 +1,15 @@
 /*
  * NotFoundPage Messages
  *
- * This contains all the text for the NotFoundPage component.
+ * This contains all the text for the NotFoundPage container.
  */
 import { defineMessages } from 'react-intl';
 
+export const scope = 'app.containers.NotFoundPage';
+
 export default defineMessages({
   header: {
-    id: 'app.components.NotFoundPage.header',
-    defaultMessage: 'This is NotFoundPage component!',
+    id: `${scope}.header`,
+    defaultMessage: 'This is the NotFoundPage container!',
   },
 });


### PR DESCRIPTION
Fixes #2361 

 - readds the changes from #1799
 - adds export directives for the message scopes for use in other files (e.g. `import messages, { scope } from '..../messages';`) 
 - updates the docs at [/docs/js/i18n.md](https://github.com/react-boilerplate/react-boilerplate/pull/2367/files?short_path=43cd55f#diff-43cd55f1b45606ea69d2083d139cd5cc)