### PR TITLE
Fix link to Contributing guidelines in PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ on something that might not end up being merged into the project.
 Before opening a pull request, please ensure:
 
 - [ ] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
-- [ ] double-check your branch is based on `dev` and targets `dev` 
+- [ ] Double-check your branch is based on `dev` and targets `dev` 
 - [ ] Pull request has tests (we are going for 100% coverage!)
 - [ ] Code is well-commented, linted and follows project conventions
 - [ ] Documentation is updated (if necessary)


### PR DESCRIPTION
Noticed the links were broken while submitting https://github.com/react-boilerplate/react-boilerplate/pull/2370

## React Boilerplate

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
- [x] double-check your branch is based on `dev` and targets `dev` 
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/react-boilerplate/react-boilerplate/blob/master/LICENSE.md).
