### PR TITLE
Path fix and lodash babel dev

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,26 +1,33 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <!-- The first thing in any HTML file should be the charset -->
-    <meta charset="utf-8">
 
-    <!-- Make the page mobile compatible -->
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+  <!-- The first thing in any HTML file should be the charset -->
+  <meta charset="utf-8">
 
-    <!-- Allow installing the app to the homescreen -->
-    <meta name="mobile-web-app-capable" content="yes">
+  <!-- Make the page mobile compatible -->
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="icon" href="/favicon.ico" />
-    <title>React.js Boilerplate</title>
-  </head>
-  <body>
-    <!-- Display a message if JS has been disabled on the browser. -->
-    <noscript>If you're seeing this message, that means <strong>JavaScript has been disabled on your browser</strong>, please <strong>enable JS</strong> to make this app work.</noscript>
+  <!-- Allow installing the app to the homescreen -->
+  <meta name="mobile-web-app-capable" content="yes">
 
-    <!-- The app hooks into this div -->
-    <div id="app"></div>
-    <!-- Open Sans Font -->
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet">
-    <!-- A lot of magic happens in this file. HtmlWebpackPlugin automatically includes all assets (e.g. bundle.js, main.css) with the correct HTML tags, which is why they are missing in this HTML file. Don't add any assets here! (Check out the webpack config files in internals/webpack for details) -->
-  </body>
+  <link rel="icon" href="/favicon.ico" />
+  <title>React.js Boilerplate</title>
+</head>
+
+<body>
+  <!-- Display a message if JS has been disabled on the browser. -->
+  <noscript>If you're seeing this message, that means
+    <strong>JavaScript has been disabled on your browser</strong>, please
+    <strong>enable JS</strong> to make this app work.</noscript>
+
+  <!-- The app hooks into this div -->
+  <div id="app"></div>
+
+  <!-- Open Sans Font -->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet">
+
+  <!-- A lot of magic happens in this file. HtmlWebpackPlugin automatically injects all assets (e.g. bundle.js, main.css) with the correct HTML tags, which is why they are missing in this file. Don't add any assets here! (Check out webpack.dev.babel.js and webpack.prod.babel.js if you want to know more) -->
+</body>
+
 </html>

--- a/app/utils/checkStore.js
+++ b/app/utils/checkStore.js
@@ -1,6 +1,4 @@
-import conformsTo from 'lodash/conformsTo';
-import isFunction from 'lodash/isFunction';
-import isObject from 'lodash/isObject';
+import { conformsTo, isFunction, isObject } from 'lodash';
 import invariant from 'invariant';
 
 /**

--- a/app/utils/reducerInjectors.js
+++ b/app/utils/reducerInjectors.js
@@ -1,7 +1,5 @@
 import invariant from 'invariant';
-import isEmpty from 'lodash/isEmpty';
-import isFunction from 'lodash/isFunction';
-import isString from 'lodash/isString';
+import { isEmpty, isFunction, isString } from 'lodash';
 
 import checkStore from './checkStore';
 import createReducer from '../reducers';

--- a/app/utils/sagaInjectors.js
+++ b/app/utils/sagaInjectors.js
@@ -1,8 +1,5 @@
-import isEmpty from 'lodash/isEmpty';
-import isFunction from 'lodash/isFunction';
-import isString from 'lodash/isString';
 import invariant from 'invariant';
-import conformsTo from 'lodash/conformsTo';
+import { isEmpty, isFunction, isString, conformsTo } from 'lodash';
 
 import checkStore from './checkStore';
 import { DAEMON, ONCE_TILL_UNMOUNT, RESTART_ON_REMOUNT } from './constants';

--- a/app/utils/tests/injectReducer.test.js
+++ b/app/utils/tests/injectReducer.test.js
@@ -5,7 +5,7 @@
 import { memoryHistory } from 'react-router-dom';
 import { shallow } from 'enzyme';
 import React from 'react';
-import identity from 'lodash/identity';
+import { identity } from 'lodash';
 
 import configureStore from '../../configureStore';
 import injectReducer from '../injectReducer';

--- a/app/utils/tests/reducerInjectors.test.js
+++ b/app/utils/tests/reducerInjectors.test.js
@@ -4,7 +4,7 @@
 
 import { memoryHistory } from 'react-router-dom';
 import { fromJS } from 'immutable';
-import identity from 'lodash/identity';
+import { identity } from 'lodash';
 
 import configureStore from '../../configureStore';
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,7 +9,6 @@ module.exports = {
     '@babel/preset-react',
   ],
   plugins: [
-    'lodash',
     'styled-components',
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-syntax-dynamic-import',
@@ -18,6 +17,7 @@ module.exports = {
     production: {
       only: ['app'],
       plugins: [
+        'lodash',
         'transform-react-remove-prop-types',
         '@babel/plugin-transform-react-inline-elements',
         '@babel/plugin-transform-react-constant-elements',

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,6 +9,7 @@ module.exports = {
     '@babel/preset-react',
   ],
   plugins: [
+    'lodash',
     'styled-components',
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-syntax-dynamic-import',

--- a/internals/scripts/dependencies.js
+++ b/internals/scripts/dependencies.js
@@ -11,11 +11,11 @@ const exists = fs.existsSync;
 const writeFile = fs.writeFileSync;
 
 const defaults = require('lodash/defaultsDeep');
-const pkg = require(path.join(process.cwd(), 'package.json'));
+const pkg = require(path.resolve(process.cwd(), 'package.json'));
 const config = require('../config');
 const dllConfig = defaults(pkg.dllPlugin, config.dllPlugin.defaults);
-const outputPath = path.join(process.cwd(), dllConfig.path);
-const dllManifestPath = path.join(outputPath, 'package.json');
+const outputPath = path.resolve(process.cwd(), dllConfig.path);
+const dllManifestPath = path.resolve(outputPath, 'package.json');
 
 /**
  * I use node_modules/react-boilerplate-dlls by default just because

--- a/internals/templates/index.html
+++ b/internals/templates/index.html
@@ -4,9 +4,14 @@
 <head>
   <!-- The first thing in any HTML file should be the charset -->
   <meta charset="utf-8">
+
   <!-- Make the page mobile compatible -->
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- Allow installing the app to the homescreen -->
   <meta name="mobile-web-app-capable" content="yes">
+
+  <link rel="icon" href="/favicon.ico" />
   <title>React.js Boilerplate</title>
 </head>
 
@@ -18,7 +23,7 @@
 
   <!-- The app hooks into this div -->
   <div id="app"></div>
-  <!-- A lot of magic happens in this file. HtmlWebpackPlugin automatically includes all assets (e.g. bundle.js, main.css) with the correct HTML tags, which is why they are missing in this HTML file. Don't add any assets here! (Check out webpackconfig.js if you want to know more) -->
+  <!-- A lot of magic happens in this file. HtmlWebpackPlugin automatically injects all assets (e.g. bundle.js, main.css) with the correct HTML tags, which is why they are missing in this file. Don't add any assets here! (Check out webpack.dev.babel.js and webpack.prod.babel.js if you want to know more) -->
 </body>
 
 </html>

--- a/internals/templates/utils/checkStore.js
+++ b/internals/templates/utils/checkStore.js
@@ -1,6 +1,4 @@
-import conformsTo from 'lodash/conformsTo';
-import isFunction from 'lodash/isFunction';
-import isObject from 'lodash/isObject';
+import { conformsTo, isFunction, isObject } from 'lodash';
 import invariant from 'invariant';
 
 /**

--- a/internals/templates/utils/reducerInjectors.js
+++ b/internals/templates/utils/reducerInjectors.js
@@ -1,7 +1,5 @@
 import invariant from 'invariant';
-import isEmpty from 'lodash/isEmpty';
-import isFunction from 'lodash/isFunction';
-import isString from 'lodash/isString';
+import { isEmpty, isFunction, isString } from 'lodash';
 
 import checkStore from './checkStore';
 import createReducer from '../reducers';

--- a/internals/templates/utils/sagaInjectors.js
+++ b/internals/templates/utils/sagaInjectors.js
@@ -1,8 +1,5 @@
-import isEmpty from 'lodash/isEmpty';
-import isFunction from 'lodash/isFunction';
-import isString from 'lodash/isString';
 import invariant from 'invariant';
-import conformsTo from 'lodash/conformsTo';
+import { isEmpty, isFunction, isString, conformsTo } from 'lodash';
 
 import checkStore from './checkStore';
 import { DAEMON, ONCE_TILL_UNMOUNT, RESTART_ON_REMOUNT } from './constants';

--- a/internals/templates/utils/tests/injectReducer.test.js
+++ b/internals/templates/utils/tests/injectReducer.test.js
@@ -5,7 +5,7 @@
 import { memoryHistory } from 'react-router-dom';
 import { shallow } from 'enzyme';
 import React from 'react';
-import identity from 'lodash/identity';
+import { identity } from 'lodash';
 
 import configureStore from '../../configureStore';
 import injectReducer from '../injectReducer';

--- a/internals/templates/utils/tests/reducerInjectors.test.js
+++ b/internals/templates/utils/tests/reducerInjectors.test.js
@@ -4,7 +4,7 @@
 
 import { memoryHistory } from 'react-router-dom';
 import { fromJS } from 'immutable';
-import identity from 'lodash/identity';
+import { identity } from 'lodash';
 
 import configureStore from '../../configureStore';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1878,6 +1878,19 @@
       "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
       "dev": true
     },
+    "babel-plugin-lodash": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
+      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0-beta.49",
+        "@babel/types": "^7.0.0-beta.49",
+        "glob": "^7.1.1",
+        "lodash": "^4.17.10",
+        "require-package-name": "^2.0.1"
+      }
+    },
     "babel-plugin-react-intl": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-intl/-/babel-plugin-react-intl-3.0.1.tgz",
@@ -13797,6 +13810,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "require-package-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+      "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=",
       "dev": true
     },
     "require-uncached": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "babel-eslint": "10.0.1",
     "babel-loader": "8.0.4",
     "babel-plugin-dynamic-import-node": "2.2.0",
+    "babel-plugin-lodash": "3.3.4",
     "babel-plugin-react-intl": "3.0.1",
     "babel-plugin-react-transform": "3.0.0",
     "babel-plugin-styled-components": "1.8.0",


### PR DESCRIPTION
Two small changes:

First, a fight to the death between `path.join` and `path.resolve` (per #2378). I think `path.join` wins. Unless it creates another issue I didn't think of?

Second, I added lodash's official [babel-plugin-lodash](https://github.com/lodash/babel-plugin-lodash) to production plugins in Babel. It replaces `import { get } from 'lodash';` with `import get from 'lodash/get';`. I know we already use the latter by default but in case a user forgets to do the same, it saves them from adding an additional 70k to their bundle.