### PR TITLE
replaced immutablejs with immer in tests and internals

### DIFF
--- a/app/containers/App/tests/reducer.test.js
+++ b/app/containers/App/tests/reducer.test.js
@@ -1,19 +1,20 @@
-import { fromJS } from 'immutable';
+import produce from 'immer';
 
 import appReducer from '../reducer';
 import { loadRepos, reposLoaded, repoLoadingError } from '../actions';
 
+/* eslint-disable default-case, no-param-reassign */
 describe('appReducer', () => {
   let state;
   beforeEach(() => {
-    state = fromJS({
+    state = {
       loading: false,
       error: false,
       currentUser: false,
-      userData: fromJS({
+      userData: {
         repositories: false,
-      }),
-    });
+      },
+    };
   });
 
   it('should return the initial state', () => {
@@ -22,10 +23,11 @@ describe('appReducer', () => {
   });
 
   it('should handle the loadRepos action correctly', () => {
-    const expectedResult = state
-      .set('loading', true)
-      .set('error', false)
-      .setIn(['userData', 'repositories'], false);
+    const expectedResult = produce(state, draft => {
+      draft.loading = true;
+      draft.error = false;
+      draft.userData.repositories = false;
+    });
 
     expect(appReducer(state, loadRepos())).toEqual(expectedResult);
   });
@@ -37,10 +39,11 @@ describe('appReducer', () => {
       },
     ];
     const username = 'test';
-    const expectedResult = state
-      .setIn(['userData', 'repositories'], fixture)
-      .set('loading', false)
-      .set('currentUser', username);
+    const expectedResult = produce(state, draft => {
+      draft.userData.repositories = fixture;
+      draft.loading = false;
+      draft.currentUser = username;
+    });
 
     expect(appReducer(state, reposLoaded(fixture, username))).toEqual(
       expectedResult,
@@ -51,7 +54,10 @@ describe('appReducer', () => {
     const fixture = {
       msg: 'Not found',
     };
-    const expectedResult = state.set('error', fixture).set('loading', false);
+    const expectedResult = produce(state, draft => {
+      draft.error = fixture;
+      draft.loading = false;
+    });
 
     expect(appReducer(state, repoLoadingError(fixture))).toEqual(
       expectedResult,

--- a/app/containers/App/tests/selectors.test.js
+++ b/app/containers/App/tests/selectors.test.js
@@ -1,5 +1,3 @@
-import { fromJS } from 'immutable';
-
 import {
   selectGlobal,
   makeSelectCurrentUser,
@@ -11,10 +9,10 @@ import {
 
 describe('selectGlobal', () => {
   it('should select the global state', () => {
-    const globalState = fromJS({});
-    const mockedState = fromJS({
+    const globalState = {};
+    const mockedState = {
       global: globalState,
-    });
+    };
     expect(selectGlobal(mockedState)).toEqual(globalState);
   });
 });
@@ -23,11 +21,11 @@ describe('makeSelectCurrentUser', () => {
   const currentUserSelector = makeSelectCurrentUser();
   it('should select the current user', () => {
     const username = 'mxstbr';
-    const mockedState = fromJS({
+    const mockedState = {
       global: {
         currentUser: username,
       },
-    });
+    };
     expect(currentUserSelector(mockedState)).toEqual(username);
   });
 });
@@ -36,11 +34,11 @@ describe('makeSelectLoading', () => {
   const loadingSelector = makeSelectLoading();
   it('should select the loading', () => {
     const loading = false;
-    const mockedState = fromJS({
+    const mockedState = {
       global: {
         loading,
       },
-    });
+    };
     expect(loadingSelector(mockedState)).toEqual(loading);
   });
 });
@@ -49,11 +47,11 @@ describe('makeSelectError', () => {
   const errorSelector = makeSelectError();
   it('should select the error', () => {
     const error = 404;
-    const mockedState = fromJS({
+    const mockedState = {
       global: {
         error,
       },
-    });
+    };
     expect(errorSelector(mockedState)).toEqual(error);
   });
 });
@@ -61,14 +59,14 @@ describe('makeSelectError', () => {
 describe('makeSelectRepos', () => {
   const reposSelector = makeSelectRepos();
   it('should select the repos', () => {
-    const repositories = fromJS([]);
-    const mockedState = fromJS({
+    const repositories = [];
+    const mockedState = {
       global: {
         userData: {
           repositories,
         },
       },
-    });
+    };
     expect(reposSelector(mockedState)).toEqual(repositories);
   });
 });
@@ -76,14 +74,12 @@ describe('makeSelectRepos', () => {
 describe('makeSelectLocation', () => {
   const locationStateSelector = makeSelectLocation();
   it('should select the location', () => {
-    const route = fromJS({
+    const router = {
       location: { pathname: '/foo' },
-    });
-    const mockedState = fromJS({
-      route,
-    });
-    expect(locationStateSelector(mockedState)).toEqual(
-      route.get('location').toJS(),
-    );
+    };
+    const mockedState = {
+      router,
+    };
+    expect(locationStateSelector(mockedState)).toEqual(router.location);
   });
 });

--- a/app/containers/HomePage/tests/reducer.test.js
+++ b/app/containers/HomePage/tests/reducer.test.js
@@ -1,14 +1,15 @@
-import { fromJS } from 'immutable';
+import produce from 'immer';
 
 import homeReducer from '../reducer';
 import { changeUsername } from '../actions';
 
+/* eslint-disable default-case, no-param-reassign */
 describe('homeReducer', () => {
   let state;
   beforeEach(() => {
-    state = fromJS({
+    state = {
       username: '',
-    });
+    };
   });
 
   it('should return the initial state', () => {
@@ -18,7 +19,9 @@ describe('homeReducer', () => {
 
   it('should handle the changeUsername action correctly', () => {
     const fixture = 'mxstbr';
-    const expectedResult = state.set('username', fixture);
+    const expectedResult = produce(state, draft => {
+      draft.username = fixture;
+    });
 
     expect(homeReducer(state, changeUsername(fixture))).toEqual(expectedResult);
   });

--- a/app/containers/HomePage/tests/selectors.test.js
+++ b/app/containers/HomePage/tests/selectors.test.js
@@ -1,15 +1,13 @@
-import { fromJS } from 'immutable';
-
 import { selectHome, makeSelectUsername } from '../selectors';
 
 describe('selectHome', () => {
   it('should select the home state', () => {
-    const homeState = fromJS({
+    const homeState = {
       userData: {},
-    });
-    const mockedState = fromJS({
+    };
+    const mockedState = {
       home: homeState,
-    });
+    };
     expect(selectHome(mockedState)).toEqual(homeState);
   });
 });
@@ -18,11 +16,11 @@ describe('makeSelectUsername', () => {
   const usernameSelector = makeSelectUsername();
   it('should select the username', () => {
     const username = 'mxstbr';
-    const mockedState = fromJS({
+    const mockedState = {
       home: {
         username,
       },
-    });
+    };
     expect(usernameSelector(mockedState)).toEqual(username);
   });
 });

--- a/app/containers/LanguageProvider/tests/reducer.test.js
+++ b/app/containers/LanguageProvider/tests/reducer.test.js
@@ -1,15 +1,12 @@
-import { fromJS } from 'immutable';
-
 import languageProviderReducer from '../reducer';
 import { CHANGE_LOCALE } from '../constants';
 
+/* eslint-disable default-case, no-param-reassign */
 describe('languageProviderReducer', () => {
   it('returns the initial state', () => {
-    expect(languageProviderReducer(undefined, {})).toEqual(
-      fromJS({
-        locale: 'en',
-      }),
-    );
+    expect(languageProviderReducer(undefined, {})).toEqual({
+      locale: 'en',
+    });
   });
 
   it('changes the locale', () => {
@@ -17,7 +14,7 @@ describe('languageProviderReducer', () => {
       languageProviderReducer(undefined, {
         type: CHANGE_LOCALE,
         locale: 'de',
-      }).toJS(),
+      }),
     ).toEqual({
       locale: 'de',
     });

--- a/app/containers/LanguageProvider/tests/selectors.test.js
+++ b/app/containers/LanguageProvider/tests/selectors.test.js
@@ -1,13 +1,11 @@
-import { fromJS } from 'immutable';
-
 import { selectLanguage } from '../selectors';
 
 describe('selectLanguage', () => {
   it('should select the global state', () => {
-    const globalState = fromJS({});
-    const mockedState = fromJS({
+    const globalState = {};
+    const mockedState = {
       language: globalState,
-    });
+    };
     expect(selectLanguage(mockedState)).toEqual(globalState);
   });
 });

--- a/app/utils/tests/reducerInjectors.test.js
+++ b/app/utils/tests/reducerInjectors.test.js
@@ -1,10 +1,9 @@
 /**
  * Test injectors
  */
-
+import produce from 'immer';
 import { memoryHistory } from 'react-router-dom';
-import { fromJS } from 'immutable';
-import identity from 'lodash/identity';
+import { identity } from 'lodash';
 
 import configureStore from '../../configureStore';
 
@@ -12,16 +11,17 @@ import getInjectors, { injectReducerFactory } from '../reducerInjectors';
 
 // Fixtures
 
-const initialState = fromJS({ reduced: 'soon' });
+const initialState = { reduced: 'soon' };
 
-const reducer = (state = initialState, action) => {
-  switch (action.type) {
-    case 'TEST':
-      return state.set('reduced', action.payload);
-    default:
-      return state;
-  }
-};
+/* eslint-disable default-case, no-param-reassign */
+const reducer = (state = initialState, action) =>
+  produce(state, draft => {
+    switch (action.type) {
+      case 'TEST':
+        draft.reduced = action.payload;
+        break;
+    }
+  });
 
 describe('reducer injectors', () => {
   let store;
@@ -74,10 +74,10 @@ describe('reducer injectors', () => {
     it('given a store, it should provide a function to inject a reducer', () => {
       injectReducer('test', reducer);
 
-      const actual = store.getState().get('test');
+      const actual = store.getState().test;
       const expected = initialState;
 
-      expect(actual.toJS()).toEqual(expected.toJS());
+      expect(actual).toEqual(expected);
     });
 
     it('should not assign reducer if already existing', () => {

--- a/internals/generators/container/reducer.js.hbs
+++ b/internals/generators/container/reducer.js.hbs
@@ -8,15 +8,15 @@ import { DEFAULT_ACTION } from './constants';
 
 export const initialState = {};
 
-function {{ camelCase name }}Reducer(state = initialState, action) {
+/* eslint-disable default-case, no-param-reassign */
+const {{ camelCase name }}Reducer = (state = initialState, action) =>
   produce(state, draft => {
     switch (action.type) {
       case DEFAULT_ACTION:
-        return state;
+        return draft;
       default:
-        return state;
+        return draft;
     }
   });
-}
 
 export default {{ camelCase name }}Reducer;

--- a/internals/generators/container/reducer.js.hbs
+++ b/internals/generators/container/reducer.js.hbs
@@ -3,19 +3,20 @@
  * {{ properCase name }} reducer
  *
  */
-
-import { fromJS } from 'immutable';
+import produce from 'immer';
 import { DEFAULT_ACTION } from './constants';
 
-export const initialState = fromJS({});
+export const initialState = {};
 
 function {{ camelCase name }}Reducer(state = initialState, action) {
-  switch (action.type) {
-    case DEFAULT_ACTION:
-      return state;
-    default:
-      return state;
-  }
+  produce(state, draft => {
+    switch (action.type) {
+      case DEFAULT_ACTION:
+        return state;
+      default:
+        return state;
+    }
+  });
 }
 
 export default {{ camelCase name }}Reducer;

--- a/internals/generators/container/reducer.test.js.hbs
+++ b/internals/generators/container/reducer.test.js.hbs
@@ -1,8 +1,32 @@
-import { fromJS } from 'immutable';
+// import produce from 'immer';
 import {{ camelCase name }}Reducer from '../reducer';
+// import { someAction } from '../actions';
 
+/* eslint-disable default-case, no-param-reassign */
 describe('{{ camelCase name }}Reducer', () => {
-  it('returns the initial state', () => {
-    expect({{ camelCase name }}Reducer(undefined, {})).toEqual(fromJS({}));
+  let state;
+  beforeEach(() => {
+    state = {
+      // default state params here
+    };
   });
+
+  it('returns the initial state', () => {
+    const expectedResult = state;
+    expect({{ camelCase name }}Reducer(undefined, {})).toEqual(expectedResult);
+  });
+
+  /**
+   * Example state change comparison
+   *
+   * it('should handle the someAction action correctly', () => {
+   *   const expectedResult = produce(state, draft => {
+   *     draft.loading = true;
+   *     draft.error = false;
+   *     draft.userData.nested = false;
+   *   });
+   * 
+   *   expect(appReducer(state, someAction())).toEqual(expectedResult);
+   * });
+   */
 });

--- a/internals/generators/container/reducer.test.js.hbs
+++ b/internals/generators/container/reducer.test.js.hbs
@@ -25,7 +25,7 @@ describe('{{ camelCase name }}Reducer', () => {
    *     draft.error = false;
    *     draft.userData.nested = false;
    *   });
-   * 
+   *
    *   expect(appReducer(state, someAction())).toEqual(expectedResult);
    * });
    */

--- a/internals/generators/container/selectors.js.hbs
+++ b/internals/generators/container/selectors.js.hbs
@@ -1,12 +1,11 @@
 import { createSelector } from 'reselect';
-import { initialState } from './reducer';
 
 /**
  * Direct selector to the {{ camelCase name }} state domain
  */
 
 const select{{ properCase name }}Domain = state =>
-  state.get('{{ camelCase name }}', initialState);
+  state.{{ camelCase name }}';
 
 /**
  * Other specific selectors
@@ -17,7 +16,7 @@ const select{{ properCase name }}Domain = state =>
  */
 
 const makeSelect{{ properCase name }} = () =>
-  createSelector(select{{ properCase name }}Domain, substate => substate.toJS());
+  createSelector(select{{ properCase name }}Domain, substate => substate);
 
 export default makeSelect{{ properCase name }};
 export { select{{ properCase name }}Domain };

--- a/internals/generators/container/selectors.js.hbs
+++ b/internals/generators/container/selectors.js.hbs
@@ -4,8 +4,7 @@ import { createSelector } from 'reselect';
  * Direct selector to the {{ camelCase name }} state domain
  */
 
-const select{{ properCase name }}Domain = state =>
-  state.{{ camelCase name }}';
+const select{{ properCase name }}Domain = state => state.{{ camelCase name }};
 
 /**
  * Other specific selectors

--- a/internals/generators/container/selectors.test.js.hbs
+++ b/internals/generators/container/selectors.test.js.hbs
@@ -1,4 +1,3 @@
-// import { fromJS } from 'immutable';
 // import { select{{ properCase name }}Domain } from '../selectors';
 
 describe('select{{ properCase name }}Domain', () => {

--- a/internals/templates/app.js
+++ b/internals/templates/app.js
@@ -12,8 +12,7 @@ import '@babel/polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import Immutable from 'immutable';
-import { ConnectedRouter } from 'connected-react-router/immutable';
+import { ConnectedRouter } from 'connected-react-router';
 import history from 'utils/history';
 import 'sanitize.css/sanitize.css';
 
@@ -38,7 +37,7 @@ import { translationMessages } from './i18n';
 import './global-styles';
 
 // Create redux store with history
-const initialState = Immutable.Map();
+const initialState = {};
 const store = configureStore(initialState, history);
 const MOUNT_NODE = document.getElementById('app');
 

--- a/internals/templates/configureStore.js
+++ b/internals/templates/configureStore.js
@@ -3,8 +3,7 @@
  */
 
 import { createStore, applyMiddleware, compose } from 'redux';
-import { fromJS } from 'immutable';
-import { routerMiddleware } from 'connected-react-router/immutable';
+import { routerMiddleware } from 'connected-react-router';
 import createSagaMiddleware from 'redux-saga';
 import createReducer from './reducers';
 
@@ -30,7 +29,7 @@ export default function configureStore(initialState = {}, history) {
 
   const store = createStore(
     createReducer(),
-    fromJS(initialState),
+    initialState,
     composeEnhancers(...enhancers),
   );
 

--- a/internals/templates/containers/App/selectors.js
+++ b/internals/templates/containers/App/selectors.js
@@ -1,8 +1,8 @@
 import { createSelector } from 'reselect';
 
-const selectRoute = state => state.get('route');
+const selectRouter = state => state.router;
 
 const makeSelectLocation = () =>
-  createSelector(selectRoute, routeState => routeState.get('location').toJS());
+  createSelector(selectRouter, routerState => routerState.location);
 
 export { makeSelectLocation };

--- a/internals/templates/containers/App/tests/selectors.test.js
+++ b/internals/templates/containers/App/tests/selectors.test.js
@@ -1,17 +1,13 @@
-import { fromJS } from 'immutable';
-
 import { makeSelectLocation } from 'containers/App/selectors';
 
 describe('makeSelectLocation', () => {
   it('should select the location', () => {
-    const route = fromJS({
+    const router = {
       location: { pathname: '/foo' },
-    });
-    const mockedState = fromJS({
-      route,
-    });
-    expect(makeSelectLocation()(mockedState)).toEqual(
-      route.get('location').toJS(),
-    );
+    };
+    const mockedState = {
+      router,
+    };
+    expect(makeSelectLocation()(mockedState)).toEqual(router.location);
   });
 });

--- a/internals/templates/containers/LanguageProvider/reducer.js
+++ b/internals/templates/containers/LanguageProvider/reducer.js
@@ -3,23 +3,23 @@
  * LanguageProvider reducer
  *
  */
-
-import { fromJS } from 'immutable';
+import produce from 'immer';
 
 import { CHANGE_LOCALE } from './constants';
-import { DEFAULT_LOCALE } from '../../i18n'; // eslint-disable-line
+import { DEFAULT_LOCALE } from '../../i18n';
 
-export const initialState = fromJS({
+export const initialState = {
   locale: DEFAULT_LOCALE,
-});
+};
 
-function languageProviderReducer(state = initialState, action) {
-  switch (action.type) {
-    case CHANGE_LOCALE:
-      return state.set('locale', action.locale);
-    default:
-      return state;
-  }
-}
+/* eslint-disable default-case, no-param-reassign */
+const languageProviderReducer = (state = initialState, action) =>
+  produce(state, draft => {
+    switch (action.type) {
+      case CHANGE_LOCALE:
+        draft.locale = action.locale;
+        break;
+    }
+  });
 
 export default languageProviderReducer;

--- a/internals/templates/reducers.js
+++ b/internals/templates/reducers.js
@@ -2,8 +2,8 @@
  * Combine all reducers in this file and export the combined reducers.
  */
 
-import { combineReducers } from 'redux-immutable';
-import { connectRouter } from 'connected-react-router/immutable';
+import { combineReducers } from 'redux';
+import { connectRouter } from 'connected-react-router';
 
 import history from 'utils/history';
 import languageProviderReducer from 'containers/LanguageProvider/reducer';

--- a/internals/templates/utils/tests/reducerInjectors.test.js
+++ b/internals/templates/utils/tests/reducerInjectors.test.js
@@ -1,10 +1,9 @@
 /**
  * Test injectors
  */
-
+import produce from 'immer';
 import { memoryHistory } from 'react-router-dom';
-import { fromJS } from 'immutable';
-import identity from 'lodash/identity';
+import { identity } from 'lodash';
 
 import configureStore from '../../configureStore';
 
@@ -12,16 +11,17 @@ import getInjectors, { injectReducerFactory } from '../reducerInjectors';
 
 // Fixtures
 
-const initialState = fromJS({ reduced: 'soon' });
+const initialState = { reduced: 'soon' };
 
-const reducer = (state = initialState, action) => {
-  switch (action.type) {
-    case 'TEST':
-      return state.set('reduced', action.payload);
-    default:
-      return state;
-  }
-};
+/* eslint-disable default-case, no-param-reassign */
+const reducer = (state = initialState, action) =>
+  produce(state, draft => {
+    switch (action.type) {
+      case 'TEST':
+        draft.reduced = action.payload;
+        break;
+    }
+  });
 
 describe('reducer injectors', () => {
   let store;
@@ -74,10 +74,10 @@ describe('reducer injectors', () => {
     it('given a store, it should provide a function to inject a reducer', () => {
       injectReducer('test', reducer);
 
-      const actual = store.getState().get('test');
+      const actual = store.getState().test;
       const expected = initialState;
 
-      expect(actual.toJS()).toEqual(expected.toJS());
+      expect(actual).toEqual(expected);
     });
 
     it('should not assign reducer if already existing', () => {


### PR DESCRIPTION
Apologies for the duplicate pull request, I wanted to fix the botched history.

Not to step on anyone's toes, but I love this boilerplate and I definitely want to use it with immer on my next project. I saw this branch and I wanted to see how it would look as far as testing goes, as well as having it implemented in any components we scaffold with reducers, so I went ahead and replaced the rest of the instances of ImmutableJS within the code. I haven't touched documentation, but I thought it might save you the bit of time it takes to refactor, should you all decide to go this route.

All Jest tests are passing.