### PR TITLE
camelCase name for saga

### DIFF
--- a/internals/generators/container/saga.js.hbs
+++ b/internals/generators/container/saga.js.hbs
@@ -1,6 +1,6 @@
 // import { take, call, put, select } from 'redux-saga/effects';
 
 // Individual exports for testing
-export default function* defaultSaga() {
+export default function* {{ camelCase name }}Saga() {
   // See example in containers/HomePage/saga.js
 }

--- a/internals/generators/container/saga.test.js.hbs
+++ b/internals/generators/container/saga.test.js.hbs
@@ -4,11 +4,11 @@
 
 /* eslint-disable redux-saga/yield-effects */
 // import { take, call, put, select } from 'redux-saga/effects';
-// import { defaultSaga } from '../saga';
+// import {{ camelCase name }}Saga from '../saga';
 
-// const generator = defaultSaga();
+// const generator = {{ camelCase name }}Saga();
 
-describe('defaultSaga Saga', () => {
+describe('{{ camelCase name }}Saga Saga', () => {
   it('Expect to have unit tests specified', () => {
     expect(true).toEqual(false);
   });


### PR DESCRIPTION
Hello guys,

Firstly, I think it will be better if generated saga file has a meaning name rather than `defaultSaga` in case of debugging.

Lastly, since `saga.js` file had a default export, so there is no reason why in `saga.test.js` file, it is imported as a single export.

Thanks for your good work.

Please let me know if I can update anything. 