### PR TITLE
Code splitting with Suspense

### DIFF
--- a/app/containers/FeaturePage/Loadable.js
+++ b/app/containers/FeaturePage/Loadable.js
@@ -2,12 +2,10 @@
  * Asynchronously loads the component for FeaturePage
  */
 
-import React, { lazy, Suspense } from 'react';
+import React from 'react';
+import loadable from 'utils/loadable';
 import LoadingIndicator from 'components/LoadingIndicator';
-const Component = lazy(() => import('./index'));
 
-export default () => (
-  <Suspense fallback={<LoadingIndicator />}>
-    <Component />
-  </Suspense>
-);
+export default loadable(() => import('./index'), {
+  fallback: <LoadingIndicator />,
+});

--- a/app/containers/FeaturePage/Loadable.js
+++ b/app/containers/FeaturePage/Loadable.js
@@ -1,10 +1,13 @@
 /**
  * Asynchronously loads the component for FeaturePage
  */
-import loadable from 'loadable-components';
 
+import React, { lazy, Suspense } from 'react';
 import LoadingIndicator from 'components/LoadingIndicator';
+const Component = lazy(() => import('./index'));
 
-export default loadable(() => import('./index'), {
-  LoadingComponent: LoadingIndicator,
-});
+export default () => (
+  <Suspense fallback={<LoadingIndicator />}>
+    <Component />
+  </Suspense>
+);

--- a/app/containers/HomePage/Loadable.js
+++ b/app/containers/HomePage/Loadable.js
@@ -2,12 +2,10 @@
  * Asynchronously loads the component for HomePage
  */
 
-import React, { lazy, Suspense } from 'react';
+import React from 'react';
+import loadable from 'utils/loadable';
 import LoadingIndicator from 'components/LoadingIndicator';
-const Component = lazy(() => import('./index'));
 
-export default () => (
-  <Suspense fallback={<LoadingIndicator />}>
-    <Component />
-  </Suspense>
-);
+export default loadable(() => import('./index'), {
+  fallback: <LoadingIndicator />,
+});

--- a/app/containers/HomePage/Loadable.js
+++ b/app/containers/HomePage/Loadable.js
@@ -1,10 +1,13 @@
 /**
  * Asynchronously loads the component for HomePage
  */
-import loadable from 'loadable-components';
 
+import React, { lazy, Suspense } from 'react';
 import LoadingIndicator from 'components/LoadingIndicator';
+const Component = lazy(() => import('./index'));
 
-export default loadable(() => import('./index'), {
-  LoadingComponent: LoadingIndicator,
-});
+export default () => (
+  <Suspense fallback={<LoadingIndicator />}>
+    <Component />
+  </Suspense>
+);

--- a/app/containers/NotFoundPage/Loadable.js
+++ b/app/containers/NotFoundPage/Loadable.js
@@ -1,10 +1,13 @@
 /**
  * Asynchronously loads the component for NotFoundPage
  */
-import loadable from 'loadable-components';
 
+import React, { lazy, Suspense } from 'react';
 import LoadingIndicator from 'components/LoadingIndicator';
+const Component = lazy(() => import('./index'));
 
-export default loadable(() => import('./index'), {
-  LoadingComponent: LoadingIndicator,
-});
+export default () => (
+  <Suspense fallback={<LoadingIndicator />}>
+    <Component />
+  </Suspense>
+);

--- a/app/containers/NotFoundPage/Loadable.js
+++ b/app/containers/NotFoundPage/Loadable.js
@@ -2,12 +2,10 @@
  * Asynchronously loads the component for NotFoundPage
  */
 
-import React, { lazy, Suspense } from 'react';
+import React from 'react';
+import loadable from 'utils/loadable';
 import LoadingIndicator from 'components/LoadingIndicator';
-const Component = lazy(() => import('./index'));
 
-export default () => (
-  <Suspense fallback={<LoadingIndicator />}>
-    <Component />
-  </Suspense>
-);
+export default loadable(() => import('./index'), {
+  fallback: <LoadingIndicator />,
+});

--- a/app/utils/loadable.js
+++ b/app/utils/loadable.js
@@ -1,6 +1,6 @@
 import React, { lazy, Suspense } from 'react';
 
-const loadable = (importFunc, { fallback }) => {
+const loadable = (importFunc, { fallback = null }) => {
   const LazyComponent = lazy(importFunc);
 
   return () => (

--- a/app/utils/loadable.js
+++ b/app/utils/loadable.js
@@ -1,0 +1,13 @@
+import React, { lazy, Suspense } from 'react';
+
+const loadable = (importFunc, { fallback }) => {
+  const LazyComponent = lazy(importFunc);
+
+  return () => (
+    <Suspense fallback={fallback}>
+      <LazyComponent />
+    </Suspense>
+  );
+};
+
+export default loadable;

--- a/app/utils/loadable.js
+++ b/app/utils/loadable.js
@@ -1,11 +1,11 @@
 import React, { lazy, Suspense } from 'react';
 
-const loadable = (importFunc, { fallback = null }) => {
+const loadable = (importFunc, { fallback = null } = { fallback: null }) => {
   const LazyComponent = lazy(importFunc);
 
-  return () => (
+  return props => (
     <Suspense fallback={fallback}>
-      <LazyComponent />
+      <LazyComponent {...props} />
     </Suspense>
   );
 };

--- a/docs/js/async-components.md
+++ b/docs/js/async-components.md
@@ -15,10 +15,9 @@ In this case, the app won't show anything while loading your component. You can 
 ```JS
 import React from 'react';
 import loadable from 'utils/loadable';
-import LoadingIndicator from 'components/LoadingIndicator';
 
 export default loadable(() => import('./index'), {
-  fallback: <LoadingIndicator />,
+  fallback: <div>Loading...</div>,
 });
 ```
 

--- a/docs/js/async-components.md
+++ b/docs/js/async-components.md
@@ -1,16 +1,11 @@
-# Loading components with loadable-components
+# Loading components with React.lazy and Suspense
 
-[`loadable-components`](https://github.com/smooth-code/loadable-components) is integrated into
-`react-boilerplate` because of its rich functionality and good design (it does not
-conflate routes with asynchronous components).
-
-To load a component asynchronously, create a `Loadable` file by hand or via component/container generators
-with the 'Do you want to load resources asynchronously?' option activated.
+To load a component asynchronously, create a `Loadable` file by hand or via component/container generators with the 'Do you want to load resources asynchronously?' option activated.
 
 This is the content of the file by default:
 
 ```JS
-import loadable from 'loadable-components';
+import loadable from 'utils/loadable';
 
 export default loadable(() => import('./index'));
 ```
@@ -18,13 +13,17 @@ export default loadable(() => import('./index'));
 In this case, the app won't show anything while loading your component. You can however make it display a custom loader with:
 
 ```JS
-import loadable from 'loadable-components';
+import React from 'react';
+import loadable from 'utils/loadable';
+import LoadingIndicator from 'components/LoadingIndicator';
 
-export default loadable(() => import('./Home'), {
-  LoadingComponent: () => <div>Loading...</div>,
-})
+export default loadable(() => import('./index'), {
+  fallback: <LoadingIndicator />,
+});
 ```
 
-`loadable-components` also allows you to do prefetching, loading multiple components in parallel, handling loading errors and plenty more.
+This feature is built into the boilerplate using React's `lazy` and `Suspense` features.
 
-You can find more information on how to use `loadable-components` in [their docs](https://github.com/smooth-code/loadable-components).
+If you need server-side rendering or are looking for more complex behaviors such as prefetching, loading multiple components in parallel, handling loading errors and more, we recommend  [loadable-components](https://github.com/smooth-code/loadable-components).
+
+You can read a comparison between our solution and that of `loadable-components` on [this page](https://www.smooth-code.com/open-source/loadable-components/docs/loadable-vs-react-lazy/).

--- a/internals/generators/component/loadable.js.hbs
+++ b/internals/generators/component/loadable.js.hbs
@@ -4,6 +4,6 @@
  *
  */
 
-import loadable from 'loadable-components';
+import loadable from 'utils/loadable';
 
 export default loadable(() => import('./index'));

--- a/internals/templates/containers/HomePage/Loadable.js
+++ b/internals/templates/containers/HomePage/Loadable.js
@@ -2,10 +2,6 @@
  * Asynchronously loads the component for HomePage
  */
 
-import React from 'react';
 import loadable from 'utils/loadable';
-import LoadingIndicator from 'components/LoadingIndicator';
 
-export default loadable(() => import('./index'), {
-  fallback: <LoadingIndicator />,
-});
+export default loadable(() => import('./index'));

--- a/internals/templates/containers/HomePage/Loadable.js
+++ b/internals/templates/containers/HomePage/Loadable.js
@@ -1,6 +1,11 @@
 /**
  * Asynchronously loads the component for HomePage
  */
-import loadable from 'loadable-components';
 
-export default loadable(() => import('./index'));
+import React from 'react';
+import loadable from 'utils/loadable';
+import LoadingIndicator from 'components/LoadingIndicator';
+
+export default loadable(() => import('./index'), {
+  fallback: <LoadingIndicator />,
+});

--- a/internals/templates/containers/NotFoundPage/Loadable.js
+++ b/internals/templates/containers/NotFoundPage/Loadable.js
@@ -2,10 +2,6 @@
  * Asynchronously loads the component for NotFoundPage
  */
 
-import React from 'react';
 import loadable from 'utils/loadable';
-import LoadingIndicator from 'components/LoadingIndicator';
 
-export default loadable(() => import('./index'), {
-  fallback: <LoadingIndicator />,
-});
+export default loadable(() => import('./index'));

--- a/internals/templates/containers/NotFoundPage/Loadable.js
+++ b/internals/templates/containers/NotFoundPage/Loadable.js
@@ -1,6 +1,11 @@
 /**
  * Asynchronously loads the component for NotFoundPage
  */
-import loadable from 'loadable-components';
 
-export default loadable(() => import('./index'));
+import React from 'react';
+import loadable from 'utils/loadable';
+import LoadingIndicator from 'components/LoadingIndicator';
+
+export default loadable(() => import('./index'), {
+  fallback: <LoadingIndicator />,
+});

--- a/internals/templates/utils/loadable.js
+++ b/internals/templates/utils/loadable.js
@@ -1,6 +1,6 @@
 import React, { lazy, Suspense } from 'react';
 
-const loadable = (importFunc, { fallback }) => {
+const loadable = (importFunc, { fallback = null }) => {
   const LazyComponent = lazy(importFunc);
 
   return () => (

--- a/internals/templates/utils/loadable.js
+++ b/internals/templates/utils/loadable.js
@@ -1,0 +1,13 @@
+import React, { lazy, Suspense } from 'react';
+
+const loadable = (importFunc, { fallback }) => {
+  const LazyComponent = lazy(importFunc);
+
+  return () => (
+    <Suspense fallback={fallback}>
+      <LazyComponent />
+    </Suspense>
+  );
+};
+
+export default loadable;

--- a/internals/templates/utils/loadable.js
+++ b/internals/templates/utils/loadable.js
@@ -1,11 +1,11 @@
 import React, { lazy, Suspense } from 'react';
 
-const loadable = (importFunc, { fallback = null }) => {
+const loadable = (importFunc, { fallback = null } = { fallback: null }) => {
   const LazyComponent = lazy(importFunc);
 
-  return () => (
+  return props => (
     <Suspense fallback={fallback}>
-      <LazyComponent />
+      <LazyComponent {...props} />
     </Suspense>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2276,11 +2276,6 @@
         "lodash": "^4.17.10"
       }
     },
-    "babel-plugin-syntax-dynamic-import": {
-      "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
-    },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
@@ -9308,15 +9303,6 @@
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
-      }
-    },
-    "loadable-components": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/loadable-components/-/loadable-components-2.2.3.tgz",
-      "integrity": "sha512-M5NYoClnlWxSbIMvKtyrtod00gf2rfBDitbTvdGjF1bGxt7nMZbCGP1N7g8CgWQWyTV7HtL86G3lunv+1GRvEg==",
-      "requires": {
-        "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "hoist-non-react-statics": "^3.0.1"
       }
     },
     "loader-runner": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3315,7 +3315,7 @@
         },
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2552,7 +2552,7 @@
         },
         "p-cancelable": {
           "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true
         },
@@ -4188,7 +4188,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -4276,13 +4276,13 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
@@ -4292,7 +4292,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -5384,7 +5384,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -6045,7 +6045,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6066,12 +6067,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6086,17 +6089,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6213,7 +6219,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6225,6 +6232,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6239,6 +6247,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6246,12 +6255,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6270,6 +6281,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6350,7 +6362,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6362,6 +6375,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6447,7 +6461,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6483,6 +6498,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6502,6 +6518,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6545,12 +6562,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7669,7 +7688,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
@@ -10834,7 +10853,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -11239,7 +11258,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11743,7 +11762,7 @@
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
       "requires": {
@@ -13251,7 +13270,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "intl": "1.2.5",
     "invariant": "2.2.4",
     "ip": "1.1.5",
-    "loadable-components": "2.2.3",
     "lodash": "4.17.11",
     "minimist": "1.2.0",
     "prop-types": "15.7.2",


### PR DESCRIPTION
With [React 16.6](https://reactjs.org/blog/2018/10/23/react-v-16-6.html#reactlazy-code-splitting-with-suspense) we can load components asynchronously using `lazy` and `Suspense`. Negligible difference in bundle size but it's still nice to use native React features instead of an additional dependency.

@gretzky @justingreenberg What do you think? Should we implement this? I'll finish the PR if relevant!