### PR TITLE
Add close-issue-app to probot

### DIFF
--- a/.github/issue-close-app.yml
+++ b/.github/issue-close-app.yml
@@ -1,0 +1,7 @@
+comment: "This issue is closed because it does not follow our issue template. Please reopen your issue with the template filled out."
+issueConfigs:
+  - content:
+    - "Issue Type"
+    - "Description"
+    - "Steps to Reproduce"
+    - "Versions"


### PR DESCRIPTION
Pushing to master because it doesn't have to do with actual development.

This adds the config file needed for close-issue-app, it looks for the headers of the issue template.

**edit** whyyy did it pull in 3 commits -_-. rebased w/ master, it should be ok now