### PR TITLE
Fix link to maintainers in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ owners to license your work under the terms of the [MIT License](https://github.
 
 # Collaborating guidelines
 
-You can find the list of all maintainers in [MAINTAINERS.md](./MAINTAINERS.md).
+You can find the list of all maintainers in [MAINTAINERS.md](./.github/MAINTAINERS.md).
 
 There are few basic rules to ensure high quality of the boilerplate:
 


### PR DESCRIPTION
## React Boilerplate

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
- [x] Double-check your branch is based on `dev` and targets `dev` 
- [ ] Pull request has tests (we are going for 100% coverage!)
- [ ] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [ ] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/react-boilerplate/react-boilerplate/blob/master/LICENSE.md).

Since it's not really a big deal, this pr fixes the link to maintainers.md in contributing.md that is broken. Not sure why maintainers.md is in .github directory.