### PR TITLE
Fix saga multiple injection problem(#2314)

### DIFF
--- a/app/utils/injectSaga.js
+++ b/app/utils/injectSaga.js
@@ -27,21 +27,33 @@ export default ({ key, saga, mode }) => WrappedComponent => {
       WrappedComponent.name ||
       'Component'})`;
 
-    componentWillMount() {
-      const { injectSaga } = this.injectors;
+    state = {
+      isReady: false,
+    };
 
-      injectSaga(key, { saga, mode }, this.props);
+    componentDidMount() {
+      const { injectSaga } = this.injectors;
+      this.isComponentMounted = true;
+      injectSaga(key, { saga, mode }, this.props).then(() => {
+        if (this.isComponentMounted) {
+          this.setState({ isReady: true });
+        }
+      });
     }
 
     componentWillUnmount() {
       const { ejectSaga } = this.injectors;
 
+      this.isComponentMounted = false;
       ejectSaga(key);
     }
 
     injectors = getInjectors(this.context.store);
 
+    isComponentMounted = false;
+
     render() {
+      if (!this.state.isReady) return null;
       return <WrappedComponent {...this.props} />;
     }
   }

--- a/app/utils/sagaInjectors.js
+++ b/app/utils/sagaInjectors.js
@@ -25,39 +25,46 @@ const checkDescriptor = descriptor => {
 
 export function injectSagaFactory(store, isValid) {
   return function injectSaga(key, descriptor = {}, args) {
-    if (!isValid) checkStore(store);
+    return new Promise((resolve, reject) => {
+      try {
+        if (!isValid) checkStore(store);
 
-    const newDescriptor = {
-      ...descriptor,
-      mode: descriptor.mode || DAEMON,
-    };
-    const { saga, mode } = newDescriptor;
+        const newDescriptor = {
+          ...descriptor,
+          mode: descriptor.mode || RESTART_ON_REMOUNT,
+        };
+        const { saga, mode } = newDescriptor;
 
-    checkKey(key);
-    checkDescriptor(newDescriptor);
+        checkKey(key);
+        checkDescriptor(newDescriptor);
 
-    let hasSaga = Reflect.has(store.injectedSagas, key);
+        let hasSaga = Reflect.has(store.injectedSagas, key);
 
-    if (process.env.NODE_ENV !== 'production') {
-      const oldDescriptor = store.injectedSagas[key];
-      // enable hot reloading of daemon and once-till-unmount sagas
-      if (hasSaga && oldDescriptor.saga !== saga) {
-        oldDescriptor.task.cancel();
-        hasSaga = false;
+        if (process.env.NODE_ENV !== 'production') {
+          const oldDescriptor = store.injectedSagas[key];
+          // enable hot reloading of daemon and once-till-unmount sagas
+          if (hasSaga && oldDescriptor.saga !== saga) {
+            oldDescriptor.task.cancel();
+            hasSaga = false;
+          }
+        }
+
+        if (
+          !hasSaga ||
+          (hasSaga && mode !== DAEMON && mode !== ONCE_TILL_UNMOUNT)
+        ) {
+          /* eslint-disable no-param-reassign */
+          store.injectedSagas[key] = {
+            ...newDescriptor,
+            task: store.runSaga(saga, args),
+          };
+          /* eslint-enable no-param-reassign */
+        }
+        resolve();
+      } catch (error) {
+        reject(error);
       }
-    }
-
-    if (
-      !hasSaga ||
-      (hasSaga && mode !== DAEMON && mode !== ONCE_TILL_UNMOUNT)
-    ) {
-      /* eslint-disable no-param-reassign */
-      store.injectedSagas[key] = {
-        ...newDescriptor,
-        task: store.runSaga(saga, args),
-      };
-      /* eslint-enable no-param-reassign */
-    }
+    });
   };
 }
 

--- a/app/utils/tests/injectSaga.test.js
+++ b/app/utils/tests/injectSaga.test.js
@@ -4,7 +4,7 @@
 
 import { memoryHistory } from 'react-router-dom';
 import { put } from 'redux-saga/effects';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import React from 'react';
 
 import configureStore from '../../configureStore';
@@ -30,7 +30,7 @@ describe('injectSaga decorator', () => {
   beforeEach(() => {
     store = configureStore({}, memoryHistory);
     injectors = {
-      injectSaga: jest.fn(),
+      injectSaga: jest.fn(() => new Promise(resolve => resolve())),
       ejectSaga: jest.fn(),
     };
     ComponentWithSaga = injectSaga({
@@ -51,6 +51,7 @@ describe('injectSaga decorator', () => {
       { saga: testSaga, mode: 'testMode' },
       props,
     );
+    expect(injectors.injectSaga()).resolves.toEqual(undefined);
   });
 
   it('should eject on unmount with a correct saga key', () => {
@@ -73,10 +74,11 @@ describe('injectSaga decorator', () => {
 
   it('should propagate props', () => {
     const props = { testProp: 'test' };
-    const renderedComponent = shallow(<ComponentWithSaga {...props} />, {
+    const renderedComponent = mount(<ComponentWithSaga {...props} />, {
       context: { store },
     });
 
+    renderedComponent.mount();
     expect(renderedComponent.prop('testProp')).toBe('test');
   });
 });

--- a/app/utils/tests/sagaInjectors.test.js
+++ b/app/utils/tests/sagaInjectors.test.js
@@ -128,7 +128,7 @@ describe('injectors', () => {
     it('should check a store if the second argument is falsy', () => {
       const inject = injectSagaFactory({});
 
-      expect(() => inject('test', testSaga)).toThrow();
+      expect(inject('test', testSaga)).rejects.toBeDefined();
     });
 
     it('it should not check a store if the second argument is true', () => {
@@ -138,26 +138,28 @@ describe('injectors', () => {
     });
 
     it("should validate saga's key", () => {
-      expect(() => injectSaga('', { saga: testSaga })).toThrow();
-      expect(() => injectSaga(1, { saga: testSaga })).toThrow();
+      expect(injectSaga('', { saga: testSaga })).rejects.toBeDefined();
+      expect(injectSaga(1, { saga: testSaga })).rejects.toBeDefined();
     });
 
     it("should validate saga's descriptor", () => {
-      expect(() => injectSaga('test')).toThrow();
-      expect(() => injectSaga('test', { saga: 1 })).toThrow();
-      expect(() =>
+      expect(injectSaga('test')).rejects.toBeDefined();
+      expect(injectSaga('test', { saga: 1 })).rejects.toBeDefined();
+      expect(
         injectSaga('test', { saga: testSaga, mode: 'testMode' }),
-      ).toThrow();
-      expect(() => injectSaga('test', { saga: testSaga, mode: 1 })).toThrow();
-      expect(() =>
+      ).rejects.toBeDefined();
+      expect(
+        injectSaga('test', { saga: testSaga, mode: 1 }),
+      ).rejects.toBeDefined();
+      expect(
         injectSaga('test', { saga: testSaga, mode: RESTART_ON_REMOUNT }),
-      ).not.toThrow();
-      expect(() =>
+      ).resolves.toEqual(undefined);
+      expect(
         injectSaga('test', { saga: testSaga, mode: DAEMON }),
-      ).not.toThrow();
-      expect(() =>
+      ).resolves.toEqual(undefined);
+      expect(
         injectSaga('test', { saga: testSaga, mode: ONCE_TILL_UNMOUNT }),
-      ).not.toThrow();
+      ).resolves.toEqual(undefined);
     });
 
     it('should pass args to saga.run', () => {


### PR DESCRIPTION
## purpose

According to the issue #2314, 
using `componentDidMount` and `Promise` to prevent saga multiple injection problem.

- `componentWillMount` has the render ordering problem ([comment](https://github.com/react-boilerplate/react-boilerplate/issues/2314#issuecomment-426911261)).
- Cuz of React v16, `componentWillMount` is unsafe and we should not use it.

Using this modification, we can assure that the order sagas are injected is correct

## order before fix
1. `Page A(1)`'s `componentWillMount`
2. `switch language (to make Page A re-Mount)`
3. `Page A(2)`'s `componentWillMount`
4. `Page A(1)`'s `componentWillUnMount`

## oder after fix 
1. `Page A(1)`'s `componentDidMount`
2. `switch language (to make Page A re-Mount)`
3. `Page A(1)`'s `componentWillUnMount`
4. `Page A(2)`'s `componentDidMount`