### PR TITLE
Use constructor instead of cWillMount for correct injection order

### DIFF
--- a/app/utils/injectReducer.js
+++ b/app/utils/injectReducer.js
@@ -23,13 +23,11 @@ export default ({ key, reducer }) => WrappedComponent => {
       WrappedComponent.name ||
       'Component'})`;
 
-    componentWillMount() {
-      const { injectReducer } = this.injectors;
+    constructor(props, context) {
+      super(props, context);
 
-      injectReducer(key, reducer);
+      getInjectors(context.store).injectReducer(key, reducer);
     }
-
-    injectors = getInjectors(this.context.store);
 
     render() {
       return <WrappedComponent {...this.props} />;

--- a/app/utils/injectSaga.js
+++ b/app/utils/injectSaga.js
@@ -9,10 +9,11 @@ import getInjectors from './sagaInjectors';
  *
  * @param {string} key A key of the saga
  * @param {function} saga A root saga that will be injected
- * @param {string} [mode] By default (constants.RESTART_ON_REMOUNT) the saga will be started on component mount and
- * cancelled with `task.cancel()` on component un-mount for improved performance. Another two options:
- *   - constants.DAEMON—starts the saga on component mount and never cancels it or starts again,
- *   - constants.ONCE_TILL_UNMOUNT—behaves like 'RESTART_ON_REMOUNT' but never runs it again.
+ * @param {string} [mode] By default (constants.DAEMON) the saga will be started
+ * on component mount and never canceled or started again. Another two options:
+ *   - constants.RESTART_ON_REMOUNT — the saga will be started on component mount and
+ *   cancelled with `task.cancel()` on component unmount for improved performance,
+ *   - constants.ONCE_TILL_UNMOUNT — behaves like 'RESTART_ON_REMOUNT' but never runs it again.
  *
  */
 export default ({ key, saga, mode }) => WrappedComponent => {
@@ -27,19 +28,17 @@ export default ({ key, saga, mode }) => WrappedComponent => {
       WrappedComponent.name ||
       'Component'})`;
 
-    componentWillMount() {
-      const { injectSaga } = this.injectors;
+    constructor(props, context) {
+      super(props, context);
 
-      injectSaga(key, { saga, mode }, this.props);
+      this.injectors = getInjectors(context.store);
+
+      this.injectors.injectSaga(key, { saga, mode }, this.props);
     }
 
     componentWillUnmount() {
-      const { ejectSaga } = this.injectors;
-
-      ejectSaga(key);
+      this.injectors.ejectSaga(key);
     }
-
-    injectors = getInjectors(this.context.store);
 
     render() {
       return <WrappedComponent {...this.props} />;

--- a/internals/templates/utils/injectReducer.js
+++ b/internals/templates/utils/injectReducer.js
@@ -23,13 +23,11 @@ export default ({ key, reducer }) => WrappedComponent => {
       WrappedComponent.name ||
       'Component'})`;
 
-    componentWillMount() {
-      const { injectReducer } = this.injectors;
+    constructor(props, context) {
+      super(props, context);
 
-      injectReducer(key, reducer);
+      getInjectors(context.store).injectReducer(key, reducer);
     }
-
-    injectors = getInjectors(this.context.store);
 
     render() {
       return <WrappedComponent {...this.props} />;

--- a/internals/templates/utils/injectSaga.js
+++ b/internals/templates/utils/injectSaga.js
@@ -9,10 +9,11 @@ import getInjectors from './sagaInjectors';
  *
  * @param {string} key A key of the saga
  * @param {function} saga A root saga that will be injected
- * @param {string} [mode] By default (constants.RESTART_ON_REMOUNT) the saga will be started on component mount and
- * cancelled with `task.cancel()` on component un-mount for improved performance. Another two options:
- *   - constants.DAEMON—starts the saga on component mount and never cancels it or starts again,
- *   - constants.ONCE_TILL_UNMOUNT—behaves like 'RESTART_ON_REMOUNT' but never runs it again.
+ * @param {string} [mode] By default (constants.DAEMON) the saga will be started
+ * on component mount and never canceled or started again. Another two options:
+ *   - constants.RESTART_ON_REMOUNT — the saga will be started on component mount and
+ *   cancelled with `task.cancel()` on component unmount for improved performance,
+ *   - constants.ONCE_TILL_UNMOUNT — behaves like 'RESTART_ON_REMOUNT' but never runs it again.
  *
  */
 export default ({ key, saga, mode }) => WrappedComponent => {
@@ -27,19 +28,17 @@ export default ({ key, saga, mode }) => WrappedComponent => {
       WrappedComponent.name ||
       'Component'})`;
 
-    componentWillMount() {
-      const { injectSaga } = this.injectors;
+    constructor(props, context) {
+      super(props, context);
 
-      injectSaga(key, { saga, mode }, this.props);
+      this.injectors = getInjectors(context.store);
+
+      this.injectors.injectSaga(key, { saga, mode }, this.props);
     }
 
     componentWillUnmount() {
-      const { ejectSaga } = this.injectors;
-
-      ejectSaga(key);
+      this.injectors.ejectSaga(key);
     }
-
-    injectors = getInjectors(this.context.store);
 
     render() {
       return <WrappedComponent {...this.props} />;


### PR DESCRIPTION
## React Boilerplate

- [x] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
- [x] Double-check your branch is based on `dev` and targets `dev` 
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

### Changelog

This is an alternative to @tonyex52's fix for #2314 in his PR #2467.

Instead of making injection Promise-based (which has a few drawbacks not addressed in #2467), we simply do the injection from the constructor.

It'll guarantee that things happen in the correct order, as described by @flameddd in #2314.

All tests are passing with no changes required.

I also did the same thing for reducer injection, if only for consistency.

Also, a small doc update that was missed when we switched the default saga injection mode to DAEMON.