### PR TITLE
Add details to lock bot message

### DIFF
--- a/.github/issue-close-app.yml
+++ b/.github/issue-close-app.yml
@@ -1,4 +1,4 @@
-comment: "This issue is closed because it does not follow our issue template. Please reopen your issue with the template filled out."
+comment: "This issue was automatically closed because it does not follow our template. Please open a new issue and fill out the template that appears instead of deleting it. It's especially important that you provide detailed steps for how to reproduce your issue."
 issueConfigs:
   - content:
     - "Issue Type"


### PR DESCRIPTION
## React Boilerplate

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
- [x] Double-check your branch is based on `dev` and targets `dev` 
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

I've seen a few people post issues without using the template who are then confused to see them locked (cf. #2471). I updated the lock bot message to hopefully remove a little bit of confusion.