### PR TITLE
Rewritten the generate-templates-for-linting script

### DIFF
--- a/internals/generators/index.js
+++ b/internals/generators/index.js
@@ -11,6 +11,12 @@ const componentGenerator = require('./component/index.js');
 const containerGenerator = require('./container/index.js');
 const languageGenerator = require('./language/index.js');
 
+/**
+ * Every generated backup file gets this extension
+ * @type {string}
+ */
+const BACKUPFILE_EXTENSION = 'rbgen';
+
 module.exports = plop => {
   plop.setGenerator('component', componentGenerator);
   plop.setGenerator('container', containerGenerator);
@@ -33,9 +39,32 @@ module.exports = plop => {
       '/../../app/',
       config.path,
       plop.getHelper('properCase')(answers.name),
+      '**',
       '**.js',
     )}`;
     exec(`npm run prettify -- "${folderPath}"`);
     return folderPath;
   });
+  plop.setActionType('backup', (answers, config) => {
+    try {
+      fs.copyFileSync(
+        path.join(__dirname, config.path, config.file),
+        path.join(
+          __dirname,
+          config.path,
+          `${config.file}.${BACKUPFILE_EXTENSION}`,
+        ),
+        'utf8',
+      );
+      return path.join(
+        __dirname,
+        config.path,
+        `${config.file}.${BACKUPFILE_EXTENSION}`,
+      );
+    } catch (err) {
+      throw err;
+    }
+  });
 };
+
+module.exports.BACKUPFILE_EXTENSION = BACKUPFILE_EXTENSION;

--- a/internals/generators/language/index.js
+++ b/internals/generators/language/index.js
@@ -34,8 +34,24 @@ module.exports = {
     },
   ],
 
-  actions: () => {
+  actions: ({ test }) => {
     const actions = [];
+
+    if (test) {
+      // backup files that will be modified so we can restore them
+      actions.push({
+        type: 'backup',
+        path: '../../app',
+        file: 'i18n.js',
+      });
+
+      actions.push({
+        type: 'backup',
+        path: '../../app',
+        file: 'app.js',
+      });
+    }
+
     actions.push({
       type: 'modify',
       path: '../../app/i18n.js',
@@ -78,14 +94,17 @@ module.exports = {
       pattern: /(import\('intl\/locale-data\/jsonp\/[a-z]+\.js'\),\n)(?!.*import\('intl\/locale-data\/jsonp\/[a-z]+\.js'\),)/g,
       templateFile: './language/polyfill-intl-locale.hbs',
     });
-    actions.push(() => {
-      const cmd = 'npm run extract-intl';
-      exec(cmd, (err, result) => {
-        if (err) throw err;
-        process.stdout.write(result);
+
+    if (!test) {
+      actions.push(() => {
+        const cmd = 'npm run extract-intl';
+        exec(cmd, (err, result) => {
+          if (err) throw err;
+          process.stdout.write(result);
+        });
+        return 'modify translation messages';
       });
-      return 'modify translation messages';
-    });
+    }
 
     return actions;
   },

--- a/internals/scripts/generate-templates-for-linting.js
+++ b/internals/scripts/generate-templates-for-linting.js
@@ -1,119 +1,391 @@
 /**
- * This script is for internal `react-boilerplate`'s usage. The only purpose of generating all of these templates is
- * to be able to lint them and detect critical errors. Every generated component's name has to start with
- * 'RbGenerated' so it can be easily excluded from the test coverage reports.
+ * This script is for internal `react-boilerplate`'s usage.
+ * It will run all generators in order to be able to lint them and detect
+ * critical errors. Every generated component's name starts with 'RbGenerated'
+ * and any modified file is backed up by a file with the same name but with the
+ * 'rbgen' extension so it can be easily excluded from the test coverage reports.
  */
 
+const chalk = require('chalk');
+const fs = require('fs');
 const nodePlop = require('node-plop');
 const path = require('path');
-const chalk = require('chalk');
 const rimraf = require('rimraf');
+const shell = require('shelljs');
 
+const addCheckmark = require('./helpers/checkmark');
 const xmark = require('./helpers/xmark');
+
+/**
+ * Every generated component/container is preceded by this
+ * @type {string}
+ */
+const { BACKUPFILE_EXTENSION } = require('../generators/index');
 
 process.chdir(path.join(__dirname, '../generators'));
 
-const prettyStringify = data => JSON.stringify(data, null, 2);
-
-const checkForErrors = result => {
-  if (Array.isArray(result.failures) && result.failures.length > 0) {
-    throw result.failures;
-  }
-};
-
-const reportErrorsFor = title => err => {
-  // TODO Replace with our own helpers/log that is guaranteed to be blocking?
-  xmark(() =>
-    console.error(
-      chalk.red(` ERROR generating '${title}': `),
-      prettyStringify(err),
-    ),
-  );
-  process.exit(1);
-};
-
-// Generated tests are designed to fail, which would in turn fail CI builds
-const removeTestsDirFrom = relativePath => () =>
-  rimraf.sync(path.join(__dirname, '/../../app/', relativePath, '/tests'));
-
 const plop = nodePlop('./index.js');
-
 const componentGen = plop.getGenerator('component');
-componentGen
-  .runActions({
-    name: 'RbGeneratedComponentEsclass',
-    type: 'React.Component',
-    wantMessages: true,
-    wantLoadable: true,
-  })
-  .then(checkForErrors)
-  .then(removeTestsDirFrom('components/RbGeneratedComponentEsclass'))
-  .catch(reportErrorsFor('component/React.Component'));
-
-componentGen
-  .runActions({
-    name: 'RbGeneratedComponentEsclasspure',
-    type: 'React.PureComponent',
-    wantMessages: true,
-    wantLoadable: true,
-  })
-  .then(checkForErrors)
-  .then(removeTestsDirFrom('components/RbGeneratedComponentEsclasspure'))
-  .catch(reportErrorsFor('component/React.PureComponent'));
-
-componentGen
-  .runActions({
-    name: 'RbGeneratedComponentStatelessfunction',
-    type: 'Stateless Function',
-    wantMessages: true,
-    wantLoadable: true,
-  })
-  .then(checkForErrors)
-  .then(removeTestsDirFrom('components/RbGeneratedComponentStatelessfunction'))
-  .catch(reportErrorsFor('component/Stateless Function'));
-
 const containerGen = plop.getGenerator('container');
-containerGen
-  .runActions({
-    name: 'RbGeneratedContainerPureComponent',
-    type: 'React.PureComponent',
-    wantHeaders: true,
-    wantActionsAndReducer: true,
-    wantSagas: true,
-    wantMessages: true,
-    wantLoadable: true,
-  })
-  .then(checkForErrors)
-  .then(removeTestsDirFrom('containers/RbGeneratedContainerPureComponent'))
-  .catch(reportErrorsFor('container/React.PureComponent'));
-
-containerGen
-  .runActions({
-    name: 'RbGeneratedContainerComponent',
-    type: 'React.Component',
-    wantHeaders: true,
-    wantActionsAndReducer: true,
-    wantSagas: true,
-    wantMessages: true,
-    wantLoadable: true,
-  })
-  .then(checkForErrors)
-  .then(removeTestsDirFrom('containers/RbGeneratedContainerComponent'))
-  .catch(reportErrorsFor('container/React.Component'));
-
-containerGen
-  .runActions({
-    name: 'RbGeneratedContainerStateless',
-    type: 'Stateless Function',
-    wantHeaders: true,
-    wantActionsAndReducer: true,
-    wantSagas: true,
-    wantMessages: true,
-    wantLoadable: true,
-  })
-  .then(checkForErrors)
-  .then(removeTestsDirFrom('containers/RbGeneratedContainerStateless'))
-  .catch(reportErrorsFor('container/Stateless'));
-
 const languageGen = plop.getGenerator('language');
-languageGen.runActions({ language: 'fr' }).catch(reportErrorsFor('language'));
+
+/**
+ * Every generated component/container is preceded by this
+ * @type {string}
+ */
+const NAMESPACE = 'RbGenerated';
+
+/**
+ * Return a prettified string
+ * @param {*} data
+ * @returns {string}
+ */
+function prettyStringify(data) {
+  return JSON.stringify(data, null, 2);
+}
+
+/**
+ * Handle results from Plop
+ * @param {array} changes
+ * @param {array} failures
+ * @returns {Promise<*>}
+ */
+function handleResult({ changes, failures }) {
+  return new Promise((resolve, reject) => {
+    if (Array.isArray(failures) && failures.length > 0) {
+      reject(new Error(prettyStringify(failures)));
+    }
+
+    resolve(changes);
+  });
+}
+
+/**
+ * Feedback to user
+ * @param {string} info
+ * @returns {Function}
+ */
+function feedbackToUser(info) {
+  return result => {
+    console.info(chalk.blue(info));
+    return result;
+  };
+}
+
+/**
+ * Report success
+ * @param {string} message
+ * @returns {Function}
+ */
+function reportSuccess(message) {
+  return result => {
+    addCheckmark(() => console.log(chalk.green(` ${message}`)));
+    return result;
+  };
+}
+
+/**
+ * Report errors
+ * @param {string} reason
+ * @returns {Function}
+ */
+function reportErrors(reason) {
+  // TODO Replace with our own helpers/log that is guaranteed to be blocking?
+  xmark(() => console.error(chalk.red(` ${reason}`)));
+  process.exit(1);
+}
+
+/**
+ * Run eslint on all js files in the given directory
+ * @param {string} relativePath
+ * @returns {Promise<string>}
+ */
+function runLintingOnDirectory(relativePath) {
+  return new Promise((resolve, reject) => {
+    shell.exec(
+      `npm run lint:eslint "app/${relativePath}/**/**.js"`,
+      {
+        silent: true,
+      },
+      code =>
+        code
+          ? reject(new Error(`Linting error(s) in ${relativePath}`))
+          : resolve(relativePath),
+    );
+  });
+}
+
+/**
+ * Run eslint on the given file
+ * @param {string} filePath
+ * @returns {Promise<string>}
+ */
+function runLintingOnFile(filePath) {
+  return new Promise((resolve, reject) => {
+    shell.exec(
+      `npm run lint:eslint "${filePath}"`,
+      {
+        silent: true,
+      },
+      code => {
+        if (code) {
+          reject(new Error(`Linting errors in ${filePath}`));
+        } else {
+          resolve(filePath);
+        }
+      },
+    );
+  });
+}
+
+/**
+ * Remove a directory
+ * @param {string} relativePath
+ * @returns {Promise<any>}
+ */
+function removeDir(relativePath) {
+  return new Promise((resolve, reject) => {
+    try {
+      rimraf(path.join(__dirname, '/../../app/', relativePath), err => {
+        if (err) throw err;
+      });
+      resolve(relativePath);
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+/**
+ * Remove a given file
+ * @param {string} filePath
+ * @returns {Promise<any>}
+ */
+function removeFile(filePath) {
+  return new Promise((resolve, reject) => {
+    try {
+      fs.unlink(filePath, err => {
+        if (err) throw err;
+      });
+      resolve(filePath);
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+/**
+ * Overwrite file from copy
+ * @param {string} filePath
+ * @param {string} [backupFileExtension=BACKUPFILE_EXTENSION]
+ * @returns {Promise<*>}
+ */
+async function restoreModifiedFile(
+  filePath,
+  backupFileExtension = BACKUPFILE_EXTENSION,
+) {
+  return new Promise((resolve, reject) => {
+    const targetFile = filePath.replace(`.${backupFileExtension}`, '');
+    try {
+      fs.copyFile(filePath, targetFile, err => {
+        if (err) throw err;
+      });
+      resolve(targetFile);
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+/**
+ * Test the component generator and rollback when successful
+ * @param {string} name - Component name
+ * @param {string} type - Plop Action type
+ * @returns {Promise<string>} - Relative path to the generated component
+ */
+async function generateComponent({ name, type }) {
+  const targetFolder = 'components';
+  const componentName = `${NAMESPACE}Component${name}`;
+  const relativePath = `${targetFolder}/${componentName}`;
+  const component = `component/${type}`;
+
+  await componentGen
+    .runActions({
+      name: componentName,
+      type,
+      wantMessages: true,
+      wantLoadable: true,
+    })
+    .then(handleResult)
+    .then(feedbackToUser(`Generated '${component}'`))
+    .catch(reason => reportErrors(reason));
+  await runLintingOnDirectory(relativePath)
+    .then(reportSuccess(`Linting test passed for '${component}'`))
+    .catch(reason => reportErrors(reason));
+  await removeDir(relativePath)
+    .then(feedbackToUser(`Cleanup '${component}'`))
+    .catch(reason => reportErrors(reason));
+
+  return component;
+}
+
+/**
+ * Test the container generator and rollback when successful
+ * @param {string} name - Container name
+ * @param {string} type - Plop Action type
+ * @returns {Promise<string>} - Relative path to the generated container
+ */
+async function generateContainer({ name, type }) {
+  const targetFolder = 'containers';
+  const componentName = `${NAMESPACE}Container${name}`;
+  const relativePath = `${targetFolder}/${componentName}`;
+  const container = `container/${type}`;
+
+  await containerGen
+    .runActions({
+      name: componentName,
+      type,
+      wantHeaders: true,
+      wantActionsAndReducer: true,
+      wantSagas: true,
+      wantMessages: true,
+      wantLoadable: true,
+    })
+    .then(handleResult)
+    .then(feedbackToUser(`Generated '${container}'`))
+    .catch(reason => reportErrors(reason));
+  await runLintingOnDirectory(relativePath)
+    .then(reportSuccess(`Linting test passed for '${container}'`))
+    .catch(reason => reportErrors(reason));
+  await removeDir(relativePath)
+    .then(feedbackToUser(`Cleanup '${container}'`))
+    .catch(reason => reportErrors(reason));
+
+  return container;
+}
+
+/**
+ * Generate components
+ * @param {array} components
+ * @returns {Promise<[string]>}
+ */
+async function generateComponents(components) {
+  const promises = components.map(async component => {
+    let result;
+
+    if (component.kind === 'component') {
+      result = await generateComponent(component);
+    } else if (component.kind === 'container') {
+      result = await generateContainer(component);
+    }
+
+    return result;
+  });
+
+  const results = await Promise.all(promises);
+
+  return results;
+}
+
+/**
+ * Test the language generator and rollback when successful
+ * @param {string} language
+ * @returns {Promise<*>}
+ */
+async function generateLanguage(language) {
+  // Run generator
+  const generatedFiles = await languageGen
+    .runActions({ language, test: true })
+    .then(handleResult)
+    .then(feedbackToUser(`Added new language: '${language}'`))
+    .then(changes =>
+      changes.reduce((acc, change) => {
+        const pathWithRemovedAnsiEscapeCodes = change.path.replace(
+          /* eslint-disable-next-line no-control-regex */
+          /(\u001b\[3(?:4|9)m)/g,
+          '',
+        );
+        const obj = {};
+        obj[pathWithRemovedAnsiEscapeCodes] = change.type;
+        return Object.assign(acc, obj);
+      }, {}),
+    )
+    .catch(reason => reportErrors(reason));
+
+  // Run eslint on modified and added JS files
+  const lintingTasks = Object.keys(generatedFiles)
+    .filter(
+      filePath =>
+        generatedFiles[filePath] === 'modify' ||
+        generatedFiles[filePath] === 'add',
+    )
+    .filter(filePath => filePath.endsWith('.js'))
+    .map(async filePath => {
+      const result = await runLintingOnFile(filePath)
+        .then(reportSuccess(`Linting test passed for '${filePath}'`))
+        .catch(reason => reportErrors(reason));
+
+      return result;
+    });
+
+  await Promise.all(lintingTasks);
+
+  // Restore modified files
+  const restoreTasks = Object.keys(generatedFiles)
+    .filter(filePath => generatedFiles[filePath] === 'backup')
+    .map(async filePath => {
+      const result = await restoreModifiedFile(filePath)
+        .then(
+          feedbackToUser(
+            `Restored file: '${filePath.replace(
+              `.${BACKUPFILE_EXTENSION}`,
+              '',
+            )}'`,
+          ),
+        )
+        .catch(reason => reportErrors(reason));
+
+      return result;
+    });
+
+  await Promise.all(restoreTasks);
+
+  // Remove backup files and added files
+  const removalTasks = Object.keys(generatedFiles)
+    .filter(
+      filePath =>
+        generatedFiles[filePath] === 'backup' ||
+        generatedFiles[filePath] === 'add',
+    )
+    .map(async filePath => {
+      const result = await removeFile(filePath)
+        .then(feedbackToUser(`Removed '${filePath}'`))
+        .catch(reason => reportErrors(reason));
+
+      return result;
+    });
+
+  await Promise.all(removalTasks);
+
+  return language;
+}
+
+/**
+ * Run
+ */
+(async function() {
+  await generateComponents([
+    { kind: 'component', name: 'Esclass', type: 'React.Component' },
+    { kind: 'component', name: 'Esclasspure', type: 'React.PureComponent' },
+    {
+      kind: 'component',
+      name: 'Statelessfunction',
+      type: 'Stateless Function',
+    },
+    { kind: 'container', name: 'Component', type: 'React.Component' },
+    { kind: 'container', name: 'PureComponent', type: 'React.PureComponent' },
+    { kind: 'container', name: 'Stateless', type: 'Stateless Function' },
+  ]).catch(reason => reportErrors(reason));
+
+  await generateLanguage('fr').catch(reason => reportErrors(reason));
+})();


### PR DESCRIPTION
## React Boilerplate

### A problem

In order to test the generator functionality the `test-generators-without-a-trace` is executed on Travis. This runs all generators for components/containers and language.
Then the linter is scheduled to run so it inlcudes these generated components etc.

But any, snapshot, test for components wrapped in `<LanguageProvider />` fail because of the added language by the language generator.

### A solution

Therefore I've rewritten the `test-generators-without-a-trace` script. It runs all generators as before but checks for linting issues right after and on the component, container or modified file, if the generation was successful.
When the generator actions were successful and no linting problems were found the component, container or any added files are removed and modified files are restored.
In case any error occured the component, container or any added files are NOT removed and modified files are NOT restored so issues can be traced.