### PR TITLE
Update babel.config.js

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -24,6 +24,7 @@ module.exports = {
       ],
     },
     test: {
+      presets: ['@babel/preset-env', '@babel/preset-react'],
       plugins: [
         '@babel/plugin-transform-modules-commonjs',
         'dynamic-import-node',


### PR DESCRIPTION
`npm run test` script throw coverage errors

Test suites fail to run throwing: 
`SyntaxError: Unexpected token { ` 
`Jest encountered an unexpected token`


Adding to babel.config.js test property fixes it: 
`test: {
      presets: ['@babel/preset-env', '@babel/preset-react'],
}`