### PR TITLE
Update issue template and issue-close-app

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,6 +22,6 @@ If applicable, add screenshots to help explain your problem.
 
 ## Versions
 
-- React-Boilerplate (see `package.json`):
+- React-Boilerplate:
 - Node/NPM:
 - Browser:

--- a/.github/issue-close-app.yml
+++ b/.github/issue-close-app.yml
@@ -1,7 +1,14 @@
-comment: "This issue was automatically closed because it does not follow our template. Please open a new issue and fill out the template that appears instead of deleting it. It's especially important that you provide detailed steps for how to reproduce your issue."
+comment: This issue was automatically closed because it does not follow either one of our templates. Please open a new issue and fill out the template that appears instead of deleting it. If you're reporting an issue, it's especially important that you provide detailed steps for how to reproduce it.
+
 issueConfigs:
+
   - content:
-    - "Issue Type"
-    - "Description"
-    - "Steps to reproduce"
-    - "Versions"
+    - Description
+    - Steps to reproduce
+    - Versions
+
+  - content:
+    - Is your feature request related to a problem
+    - Describe the solution you'd like
+    - Describe alternatives you've considered
+    - Additional context


### PR DESCRIPTION
I think these changes would allow us to turn the issue close bot back on. Do you agree?

(I removed the mention of package.json because I'm assuming most users overwrite the version when starting to build their own apps. In fact, we probably ought to set it to 0.1.0 or something similar in the setup script.)

- [x] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
- [x] Double-check your branch is based on `dev` and targets `dev` 
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues