### PR TITLE
Remove process.noDeprecation = true

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -5,12 +5,6 @@
 const path = require('path');
 const webpack = require('webpack');
 
-// Remove this line once the following warning goes away (it was meant for webpack loader authors not users):
-// 'DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic,
-// see https://github.com/webpack/loader-utils/issues/56 parseQuery() will be replaced with getOptions()
-// in the next major version of loader-utils.'
-process.noDeprecation = true;
-
 module.exports = options => ({
   mode: options.mode,
   entry: options.entry,


### PR DESCRIPTION
All webpack loaders seem to have upgraded to the new version of `loader-utils`, i am not getting any more errors in my project after removing the line.