### PR TITLE
[RFC] Hooks-based saga and reducer injectors

### DIFF
--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -8,25 +8,22 @@ import HeaderLink from './HeaderLink';
 import Banner from './banner.jpg';
 import messages from './messages';
 
-/* eslint-disable react/prefer-stateless-function */
-class Header extends React.Component {
-  render() {
-    return (
-      <div>
-        <A href="https://twitter.com/mxstbr">
-          <Img src={Banner} alt="react-boilerplate - Logo" />
-        </A>
-        <NavBar>
-          <HeaderLink to="/">
-            <FormattedMessage {...messages.home} />
-          </HeaderLink>
-          <HeaderLink to="/features">
-            <FormattedMessage {...messages.features} />
-          </HeaderLink>
-        </NavBar>
-      </div>
-    );
-  }
+function Header() {
+  return (
+    <div>
+      <A href="https://www.reactboilerplate.com/">
+        <Img src={Banner} alt="react-boilerplate - Logo" />
+      </A>
+      <NavBar>
+        <HeaderLink to="/">
+          <FormattedMessage {...messages.home} />
+        </HeaderLink>
+        <HeaderLink to="/features">
+          <FormattedMessage {...messages.features} />
+        </HeaderLink>
+      </NavBar>
+    </div>
+  );
 }
 
 export default Header;

--- a/app/components/Header/tests/__snapshots__/index.test.js.snap
+++ b/app/components/Header/tests/__snapshots__/index.test.js.snap
@@ -4,7 +4,7 @@ exports[`<Header /> should render a div 1`] = `
 <div>
   <a
     class="A-br8h0y-0 A-p44m4v-0 cYguYL"
-    href="https://twitter.com/mxstbr"
+    href="https://www.reactboilerplate.com/"
   >
     <img
       alt="react-boilerplate - Logo"

--- a/app/containers/FeaturePage/index.js
+++ b/app/containers/FeaturePage/index.js
@@ -13,73 +13,65 @@ import List from './List';
 import ListItem from './ListItem';
 import ListItemTitle from './ListItemTitle';
 
-export default class FeaturePage extends React.Component {
-  // Since state and props are static,
-  // there's no need to re-render this component
-  shouldComponentUpdate() {
-    return false;
-  }
+export default function FeaturePage() {
+  return (
+    <div>
+      <Helmet>
+        <title>Feature Page</title>
+        <meta
+          name="description"
+          content="Feature page of React.js Boilerplate application"
+        />
+      </Helmet>
+      <H1>
+        <FormattedMessage {...messages.header} />
+      </H1>
+      <List>
+        <ListItem>
+          <ListItemTitle>
+            <FormattedMessage {...messages.scaffoldingHeader} />
+          </ListItemTitle>
+          <p>
+            <FormattedMessage {...messages.scaffoldingMessage} />
+          </p>
+        </ListItem>
 
-  render() {
-    return (
-      <div>
-        <Helmet>
-          <title>Feature Page</title>
-          <meta
-            name="description"
-            content="Feature page of React.js Boilerplate application"
-          />
-        </Helmet>
-        <H1>
-          <FormattedMessage {...messages.header} />
-        </H1>
-        <List>
-          <ListItem>
-            <ListItemTitle>
-              <FormattedMessage {...messages.scaffoldingHeader} />
-            </ListItemTitle>
-            <p>
-              <FormattedMessage {...messages.scaffoldingMessage} />
-            </p>
-          </ListItem>
+        <ListItem>
+          <ListItemTitle>
+            <FormattedMessage {...messages.feedbackHeader} />
+          </ListItemTitle>
+          <p>
+            <FormattedMessage {...messages.feedbackMessage} />
+          </p>
+        </ListItem>
 
-          <ListItem>
-            <ListItemTitle>
-              <FormattedMessage {...messages.feedbackHeader} />
-            </ListItemTitle>
-            <p>
-              <FormattedMessage {...messages.feedbackMessage} />
-            </p>
-          </ListItem>
+        <ListItem>
+          <ListItemTitle>
+            <FormattedMessage {...messages.routingHeader} />
+          </ListItemTitle>
+          <p>
+            <FormattedMessage {...messages.routingMessage} />
+          </p>
+        </ListItem>
 
-          <ListItem>
-            <ListItemTitle>
-              <FormattedMessage {...messages.routingHeader} />
-            </ListItemTitle>
-            <p>
-              <FormattedMessage {...messages.routingMessage} />
-            </p>
-          </ListItem>
+        <ListItem>
+          <ListItemTitle>
+            <FormattedMessage {...messages.networkHeader} />
+          </ListItemTitle>
+          <p>
+            <FormattedMessage {...messages.networkMessage} />
+          </p>
+        </ListItem>
 
-          <ListItem>
-            <ListItemTitle>
-              <FormattedMessage {...messages.networkHeader} />
-            </ListItemTitle>
-            <p>
-              <FormattedMessage {...messages.networkMessage} />
-            </p>
-          </ListItem>
-
-          <ListItem>
-            <ListItemTitle>
-              <FormattedMessage {...messages.intlHeader} />
-            </ListItemTitle>
-            <p>
-              <FormattedMessage {...messages.intlMessage} />
-            </p>
-          </ListItem>
-        </List>
-      </div>
-    );
-  }
+        <ListItem>
+          <ListItemTitle>
+            <FormattedMessage {...messages.intlHeader} />
+          </ListItemTitle>
+          <p>
+            <FormattedMessage {...messages.intlMessage} />
+          </p>
+        </ListItem>
+      </List>
+    </div>
+  );
 }

--- a/app/containers/FeaturePage/tests/index.test.js
+++ b/app/containers/FeaturePage/tests/index.test.js
@@ -16,24 +16,4 @@ describe('<FeaturePage />', () => {
 
     expect(firstChild).toMatchSnapshot();
   });
-
-  it('should never re-render the component', () => {
-    const shouldComponentUpdateMock = jest.spyOn(
-      FeaturePage.prototype,
-      'shouldComponentUpdate',
-    );
-    const { rerender } = render(
-      <IntlProvider locale="en">
-        <FeaturePage />
-      </IntlProvider>,
-    );
-
-    rerender(
-      <IntlProvider locale="en">
-        <FeaturePage test="dummy" />
-      </IntlProvider>,
-    );
-
-    expect(shouldComponentUpdateMock).toHaveReturnedWith(false);
-  });
 });

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -35,7 +35,7 @@ import saga from './saga';
 
 const key = 'home';
 
-function HomePage({
+export function HomePage({
   username,
   loading,
   error,

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -12,8 +12,8 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { createStructuredSelector } from 'reselect';
 
-import injectReducer from 'utils/injectReducer';
-import injectSaga from 'utils/injectSaga';
+import { useReduxReducer } from 'utils/injectReducer';
+import { useSaga } from 'utils/injectSaga';
 import {
   makeSelectRepos,
   makeSelectLoading,
@@ -33,68 +33,72 @@ import { makeSelectUsername } from './selectors';
 import reducer from './reducer';
 import saga from './saga';
 
-/* eslint-disable react/prefer-stateless-function */
-export class HomePage extends React.PureComponent {
-  /**
-   * when initial state username is not null, submit the form to load repos
-   */
-  componentDidMount() {
-    if (this.props.username && this.props.username.trim().length > 0) {
-      this.props.onSubmitForm();
-    }
-  }
+const key = 'home';
 
-  render() {
-    const { loading, error, repos } = this.props;
-    const reposListProps = {
-      loading,
-      error,
-      repos,
-    };
+function HomePage({
+  username,
+  loading,
+  error,
+  repos,
+  onSubmitForm,
+  onChangeUsername,
+}) {
+  useReduxReducer({ key, reducer });
+  useSaga({ key, saga });
 
-    return (
-      <article>
-        <Helmet>
-          <title>Home Page</title>
-          <meta
-            name="description"
-            content="A React.js Boilerplate application homepage"
-          />
-        </Helmet>
-        <div>
-          <CenteredSection>
-            <H2>
-              <FormattedMessage {...messages.startProjectHeader} />
-            </H2>
-            <p>
-              <FormattedMessage {...messages.startProjectMessage} />
-            </p>
-          </CenteredSection>
-          <Section>
-            <H2>
-              <FormattedMessage {...messages.trymeHeader} />
-            </H2>
-            <Form onSubmit={this.props.onSubmitForm}>
-              <label htmlFor="username">
-                <FormattedMessage {...messages.trymeMessage} />
-                <AtPrefix>
-                  <FormattedMessage {...messages.trymeAtPrefix} />
-                </AtPrefix>
-                <Input
-                  id="username"
-                  type="text"
-                  placeholder="mxstbr"
-                  value={this.props.username}
-                  onChange={this.props.onChangeUsername}
-                />
-              </label>
-            </Form>
-            <ReposList {...reposListProps} />
-          </Section>
-        </div>
-      </article>
-    );
-  }
+  React.useEffect(() => {
+    // When initial state username is not null, submit the form to load repos
+    if (username && username.trim().length > 0) onSubmitForm();
+  }, []);
+
+  const reposListProps = {
+    loading,
+    error,
+    repos,
+  };
+
+  return (
+    <article>
+      <Helmet>
+        <title>Home Page</title>
+        <meta
+          name="description"
+          content="A React.js Boilerplate application homepage"
+        />
+      </Helmet>
+      <div>
+        <CenteredSection>
+          <H2>
+            <FormattedMessage {...messages.startProjectHeader} />
+          </H2>
+          <p>
+            <FormattedMessage {...messages.startProjectMessage} />
+          </p>
+        </CenteredSection>
+        <Section>
+          <H2>
+            <FormattedMessage {...messages.trymeHeader} />
+          </H2>
+          <Form onSubmit={onSubmitForm}>
+            <label htmlFor="username">
+              <FormattedMessage {...messages.trymeMessage} />
+              <AtPrefix>
+                <FormattedMessage {...messages.trymeAtPrefix} />
+              </AtPrefix>
+              <Input
+                id="username"
+                type="text"
+                placeholder="mxstbr"
+                value={username}
+                onChange={onChangeUsername}
+              />
+            </label>
+          </Form>
+          <ReposList {...reposListProps} />
+        </Section>
+      </div>
+    </article>
+  );
 }
 
 HomePage.propTypes = {
@@ -128,11 +132,4 @@ const withConnect = connect(
   mapDispatchToProps,
 );
 
-const withReducer = injectReducer({ key: 'home', reducer });
-const withSaga = injectSaga({ key: 'home', saga });
-
-export default compose(
-  withReducer,
-  withSaga,
-  withConnect,
-)(HomePage);
+export default compose(withConnect)(HomePage);

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -12,8 +12,8 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { createStructuredSelector } from 'reselect';
 
-import { useReduxReducer } from 'utils/injectReducer';
-import { useSaga } from 'utils/injectSaga';
+import { useInjectReducer } from 'utils/injectReducer';
+import { useInjectSaga } from 'utils/injectSaga';
 import {
   makeSelectRepos,
   makeSelectLoading,
@@ -43,8 +43,8 @@ function HomePage({
   onSubmitForm,
   onChangeUsername,
 }) {
-  useReduxReducer({ key, reducer });
-  useSaga({ key, saga });
+  useInjectReducer({ key, reducer });
+  useInjectSaga({ key, saga });
 
   React.useEffect(() => {
     // When initial state username is not null, submit the form to load repos

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -4,7 +4,7 @@
  * This is the first thing users see of our App, at the '/' route
  */
 
-import React from 'react';
+import React, { useEffect, memo } from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { FormattedMessage } from 'react-intl';
@@ -46,7 +46,7 @@ function HomePage({
   useInjectReducer({ key, reducer });
   useInjectSaga({ key, saga });
 
-  React.useEffect(() => {
+  useEffect(() => {
     // When initial state username is not null, submit the form to load repos
     if (username && username.trim().length > 0) onSubmitForm();
   }, []);
@@ -132,4 +132,7 @@ const withConnect = connect(
   mapDispatchToProps,
 );
 
-export default compose(withConnect)(HomePage);
+export default compose(
+  withConnect,
+  memo,
+)(HomePage);

--- a/app/containers/HomePage/tests/index.test.js
+++ b/app/containers/HomePage/tests/index.test.js
@@ -5,33 +5,46 @@
 import React from 'react';
 import { render } from 'react-testing-library';
 import { IntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
+import { browserHistory } from 'react-router-dom';
 
 import { HomePage, mapDispatchToProps } from '../index';
 import { changeUsername } from '../actions';
 import { loadRepos } from '../../App/actions';
+import configureStore from '../../../configureStore';
 
 describe('<HomePage />', () => {
+  let store;
+
+  beforeAll(() => {
+    store = configureStore({}, browserHistory);
+  });
+
   it('should render and match the snapshot', () => {
     const {
       container: { firstChild },
     } = render(
-      <IntlProvider locale="en">
-        <HomePage loading={false} error={false} repos={[]} />
-      </IntlProvider>,
+      <Provider store={store}>
+        <IntlProvider locale="en">
+          <HomePage loading={false} error={false} repos={[]} />
+        </IntlProvider>
+      </Provider>,
     );
     expect(firstChild).toMatchSnapshot();
   });
 
-  it('should render fetch the repos on mount if a username exists', () => {
+  it('should fetch the repos on mount if a username exists', () => {
     const submitSpy = jest.fn();
     render(
-      <IntlProvider locale="en">
-        <HomePage
-          username="Not Empty"
-          onChangeUsername={() => {}}
-          onSubmitForm={submitSpy}
-        />
-      </IntlProvider>,
+      <Provider store={store}>
+        <IntlProvider locale="en">
+          <HomePage
+            username="Not Empty"
+            onChangeUsername={() => {}}
+            onSubmitForm={submitSpy}
+          />
+        </IntlProvider>
+      </Provider>,
     );
     expect(submitSpy).toHaveBeenCalled();
   });
@@ -39,9 +52,11 @@ describe('<HomePage />', () => {
   it('should not call onSubmitForm if username is an empty string', () => {
     const submitSpy = jest.fn();
     render(
-      <IntlProvider locale="en">
-        <HomePage onChangeUsername={() => {}} onSubmitForm={submitSpy} />
-      </IntlProvider>,
+      <Provider store={store}>
+        <IntlProvider locale="en">
+          <HomePage onChangeUsername={() => {}} onSubmitForm={submitSpy} />
+        </IntlProvider>
+      </Provider>,
     );
     expect(submitSpy).not.toHaveBeenCalled();
   });
@@ -49,13 +64,15 @@ describe('<HomePage />', () => {
   it('should not call onSubmitForm if username is null', () => {
     const submitSpy = jest.fn();
     render(
-      <IntlProvider locale="en">
-        <HomePage
-          username=""
-          onChangeUsername={() => {}}
-          onSubmitForm={submitSpy}
-        />
-      </IntlProvider>,
+      <Provider store={store}>
+        <IntlProvider locale="en">
+          <HomePage
+            username=""
+            onChangeUsername={() => {}}
+            onSubmitForm={submitSpy}
+          />
+        </IntlProvider>
+      </Provider>,
     );
     expect(submitSpy).not.toHaveBeenCalled();
   });

--- a/app/containers/LanguageProvider/index.js
+++ b/app/containers/LanguageProvider/index.js
@@ -14,18 +14,16 @@ import { IntlProvider } from 'react-intl';
 
 import { makeSelectLocale } from './selectors';
 
-export class LanguageProvider extends React.PureComponent {
-  render() {
-    return (
-      <IntlProvider
-        locale={this.props.locale}
-        key={this.props.locale}
-        messages={this.props.messages[this.props.locale]}
-      >
-        {React.Children.only(this.props.children)}
-      </IntlProvider>
-    );
-  }
+export function LanguageProvider(props) {
+  return (
+    <IntlProvider
+      locale={props.locale}
+      key={props.locale}
+      messages={props.messages[props.locale]}
+    >
+      {React.Children.only(props.children)}
+    </IntlProvider>
+  );
 }
 
 LanguageProvider.propTypes = {

--- a/app/containers/LocaleToggle/index.js
+++ b/app/containers/LocaleToggle/index.js
@@ -16,20 +16,17 @@ import { appLocales } from '../../i18n';
 import { changeLocale } from '../LanguageProvider/actions';
 import { makeSelectLocale } from '../LanguageProvider/selectors';
 
-export class LocaleToggle extends React.PureComponent {
-  // eslint-disable-line react/prefer-stateless-function
-  render() {
-    return (
-      <Wrapper>
-        <Toggle
-          value={this.props.locale}
-          values={appLocales}
-          messages={messages}
-          onToggle={this.props.onLocaleToggle}
-        />
-      </Wrapper>
-    );
-  }
+export function LocaleToggle(props) {
+  return (
+    <Wrapper>
+      <Toggle
+        value={props.locale}
+        values={appLocales}
+        messages={messages}
+        onToggle={props.onLocaleToggle}
+      />
+    </Wrapper>
+  );
 }
 
 LocaleToggle.propTypes = {

--- a/app/containers/RepoListItem/index.js
+++ b/app/containers/RepoListItem/index.js
@@ -17,33 +17,31 @@ import IssueLink from './IssueLink';
 import RepoLink from './RepoLink';
 import Wrapper from './Wrapper';
 
-export class RepoListItem extends React.PureComponent {
-  render() {
-    const { item } = this.props;
-    let nameprefix = '';
+export function RepoListItem(props) {
+  const { item } = props;
+  let nameprefix = '';
 
-    // If the repository is owned by a different person than we got the data for
-    // it's a fork and we should show the name of the owner
-    if (item.owner.login !== this.props.currentUser) {
-      nameprefix = `${item.owner.login}/`;
-    }
-
-    // Put together the content of the repository
-    const content = (
-      <Wrapper>
-        <RepoLink href={item.html_url} target="_blank">
-          {nameprefix + item.name}
-        </RepoLink>
-        <IssueLink href={`${item.html_url}/issues`} target="_blank">
-          <IssueIcon />
-          <FormattedNumber value={item.open_issues_count} />
-        </IssueLink>
-      </Wrapper>
-    );
-
-    // Render the content into a list item
-    return <ListItem key={`repo-list-item-${item.full_name}`} item={content} />;
+  // If the repository is owned by a different person than we got the data for
+  // it's a fork and we should show the name of the owner
+  if (item.owner.login !== props.currentUser) {
+    nameprefix = `${item.owner.login}/`;
   }
+
+  // Put together the content of the repository
+  const content = (
+    <Wrapper>
+      <RepoLink href={item.html_url} target="_blank">
+        {nameprefix + item.name}
+      </RepoLink>
+      <IssueLink href={`${item.html_url}/issues`} target="_blank">
+        <IssueIcon />
+        <FormattedNumber value={item.open_issues_count} />
+      </IssueLink>
+    </Wrapper>
+  );
+
+  // Render the content into a list item
+  return <ListItem key={`repo-list-item-${item.full_name}`} item={content} />;
 }
 
 RepoListItem.propTypes = {

--- a/app/utils/injectReducer.js
+++ b/app/utils/injectReducer.js
@@ -34,3 +34,12 @@ export default ({ key, reducer }) => WrappedComponent => {
 
   return hoistNonReactStatics(ReducerInjector, WrappedComponent);
 };
+
+const useReduxReducer = ({ key, reducer }) => {
+  const context = React.useContext(ReactReduxContext);
+  React.useEffect(() => {
+    getInjectors(context.store).injectReducer(key, reducer);
+  }, []);
+};
+
+export { useReduxReducer };

--- a/app/utils/injectReducer.js
+++ b/app/utils/injectReducer.js
@@ -35,11 +35,11 @@ export default ({ key, reducer }) => WrappedComponent => {
   return hoistNonReactStatics(ReducerInjector, WrappedComponent);
 };
 
-const useReduxReducer = ({ key, reducer }) => {
+const useInjectReducer = ({ key, reducer }) => {
   const context = React.useContext(ReactReduxContext);
   React.useEffect(() => {
     getInjectors(context.store).injectReducer(key, reducer);
   }, []);
 };
 
-export { useReduxReducer };
+export { useInjectReducer };

--- a/app/utils/injectSaga.js
+++ b/app/utils/injectSaga.js
@@ -46,7 +46,7 @@ export default ({ key, saga, mode }) => WrappedComponent => {
   return hoistNonReactStatics(InjectSaga, WrappedComponent);
 };
 
-const useSaga = ({ key, saga, mode }) => {
+const useInjectSaga = ({ key, saga, mode }) => {
   const context = React.useContext(ReactReduxContext);
   React.useEffect(() => {
     const injectors = getInjectors(context.store);
@@ -58,4 +58,4 @@ const useSaga = ({ key, saga, mode }) => {
   }, []);
 };
 
-export { useSaga };
+export { useInjectSaga };

--- a/app/utils/injectSaga.js
+++ b/app/utils/injectSaga.js
@@ -45,3 +45,17 @@ export default ({ key, saga, mode }) => WrappedComponent => {
 
   return hoistNonReactStatics(InjectSaga, WrappedComponent);
 };
+
+const useSaga = ({ key, saga, mode }) => {
+  const context = React.useContext(ReactReduxContext);
+  React.useEffect(() => {
+    const injectors = getInjectors(context.store);
+    injectors.injectSaga(key, { saga, mode });
+
+    return () => {
+      injectors.ejectSaga(key);
+    };
+  }, []);
+};
+
+export { useSaga };

--- a/internals/templates/containers/HomePage/index.js
+++ b/internals/templates/containers/HomePage/index.js
@@ -3,23 +3,16 @@
  *
  * This is the first thing users see of our App, at the '/' route
  *
- * NOTE: while this component should technically be a stateless functional
- * component (SFC), hot reloading does not currently support SFCs. If hot
- * reloading is not a necessity for you then you can refactor it and remove
- * the linting exception.
  */
 
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import messages from './messages';
 
-/* eslint-disable react/prefer-stateless-function */
-export default class HomePage extends React.PureComponent {
-  render() {
-    return (
-      <h1>
-        <FormattedMessage {...messages.header} />
-      </h1>
-    );
-  }
+export default function HomePage() {
+  return (
+    <h1>
+      <FormattedMessage {...messages.header} />
+    </h1>
+  );
 }

--- a/internals/templates/containers/LanguageProvider/index.js
+++ b/internals/templates/containers/LanguageProvider/index.js
@@ -14,19 +14,16 @@ import { IntlProvider } from 'react-intl';
 
 import { makeSelectLocale } from './selectors';
 
-export class LanguageProvider extends React.PureComponent {
-  // eslint-disable-line react/prefer-stateless-function
-  render() {
-    return (
-      <IntlProvider
-        locale={this.props.locale}
-        key={this.props.locale}
-        messages={this.props.messages[this.props.locale]}
-      >
-        {React.Children.only(this.props.children)}
-      </IntlProvider>
-    );
-  }
+export function LanguageProvider(props) {
+  return (
+    <IntlProvider
+      locale={props.locale}
+      key={props.locale}
+      messages={props.messages[props.locale]}
+    >
+      {React.Children.only(props.children)}
+    </IntlProvider>
+  );
 }
 
 LanguageProvider.propTypes = {

--- a/internals/templates/containers/NotFoundPage/index.js
+++ b/internals/templates/containers/NotFoundPage/index.js
@@ -14,13 +14,10 @@ import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
 
-/* eslint-disable react/prefer-stateless-function */
-export default class NotFound extends React.PureComponent {
-  render() {
-    return (
-      <h1>
-        <FormattedMessage {...messages.header} />
-      </h1>
-    );
-  }
+export default function NotFound() {
+  return (
+    <h1>
+      <FormattedMessage {...messages.header} />
+    </h1>
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4517,11 +4517,6 @@
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -12025,14 +12020,19 @@
         "scheduler": "^0.13.4"
       }
     },
+    "react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
     "react-helmet": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.0.tgz",
-      "integrity": "sha1-qBgR3yExOm1VxfBYxK66XW89l6c=",
+      "version": "6.0.0-beta",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.0.0-beta.tgz",
+      "integrity": "sha512-GnNWsokebTe7fe8MH2I/a2dl4THYWhthLBoMaQSRYqW5XbPo881WAJGi+lqRBjyOFryW6zpQluEkBy70zh+h9w==",
       "requires": {
-        "deep-equal": "^1.0.1",
         "object-assign": "^4.1.1",
         "prop-types": "^15.5.4",
+        "react-fast-compare": "^2.0.2",
         "react-side-effect": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "prop-types": "15.7.2",
     "react": "16.8.4",
     "react-dom": "16.8.4",
-    "react-helmet": "5.2.0",
+    "react-helmet": "6.0.0-beta",
     "react-intl": "2.8.0",
     "react-redux": "6.0.1",
     "react-router-dom": "4.3.1",


### PR DESCRIPTION
## React Boilerplate

The saga and reducer injectors are normally used via HOCs.

The HOCs will still work with Hooks-based components but IMO, we can offer a nice alternative which doesn't pollute the render tree:

`useInjectSaga` and `useInjectReducer` hooks!

You can see this alternative in this PR's diff [here](https://github.com/react-boilerplate/react-boilerplate/pull/2583/files?w=1) (with the no whitespace option enabled).

We probably shouldn't remove the HOCs as the Hooks-based injectors won't work with Class components.

I do have one question about the InjectSaga HOC: It passes props to `injectSaga`. What's the purpose of this and is there any way around it?

This is more of an RFC than anything else. Looking for thoughts and feedback before completing the branch.

Cheers!

PS: `react-helmet@5` + `useEffect` in the same component = 🧨💥🔥 so I upgraded us to the 6.0.0 beta.

![image](https://user-images.githubusercontent.com/8948127/53353299-13340a80-392d-11e9-8230-4fb0e7992191.png)
