### PR TITLE
Manually fix conflict between master and dev to enable merging master…

### DIFF
--- a/.github/issue-close-app.yml
+++ b/.github/issue-close-app.yml
@@ -1,7 +1,14 @@
-comment: "This issue was automatically closed because it does not follow our template. Please open a new issue and fill out the template that appears instead of deleting it. It's especially important that you provide detailed steps for how to reproduce your issue."
+comment: This issue was automatically closed because it does not follow either one of our templates. Please open a new issue and fill out the template that appears instead of deleting it. If you're reporting an issue, it's especially important that you provide detailed steps for how to reproduce it.
+
 issueConfigs:
+
   - content:
-    - "Issue Type"
-    - "Description"
-    - "Steps to reproduce"
-    - "Versions"
+    - Description
+    - Steps to reproduce
+    - Versions
+
+  - content:
+    - Is your feature request related to a problem
+    - Describe the solution you'd like
+    - Describe alternatives you've considered
+    - Additional context


### PR DESCRIPTION
## React Boilerplate

#2582 cannot be merged because of a conflict in `.github/issue-close-app.yml` and Github says the conflict can't be fixed because `master` is protected. This PR brings `master`'s version of `.github/issue-close-app.yml` into `dev`. I think it should remove the conflict from #2582. No?