### PR TITLE
Fix for double comma linting issue

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,6 @@ module.exports = {
     'compat/compat': 'error',
     'arrow-body-style': [2, 'as-needed'],
     'class-methods-use-this': 0,
-    'comma-dangle': [2, 'always-multiline'],
     'import/imports-first': 0,
     'import/newline-after-import': 0,
     'import/no-dynamic-require': 0,


### PR DESCRIPTION
## React Boilerplate

ESLint's IDE extensions always add two trailing commas per line when writing an object, an array, or a list of arguments, etc. It can be very annoying. This is a quick fix for this issue. The prettier config + its ESLint plugin already take care of trailing commas for us so in this branch I removed the dedicated ESLint rule. The bug goes away when you do that.