### PR TITLE
Move react-testing-library cleanup to Jest config

### DIFF
--- a/app/components/A/tests/index.test.js
+++ b/app/components/A/tests/index.test.js
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { render, cleanup } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import A from '../index';
 
@@ -17,8 +17,6 @@ const renderComponent = (props = {}) =>
   );
 
 describe('<A />', () => {
-  afterEach(cleanup);
-
   it('should render an <a> tag', () => {
     const { container } = renderComponent();
     expect(container.querySelector('a')).not.toBeNull();

--- a/app/components/Button/tests/A.test.js
+++ b/app/components/Button/tests/A.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { render, cleanup } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import A from '../A';
 
 describe('<A />', () => {
-  afterEach(cleanup);
-
   it('should render an <a> tag', () => {
     const { container } = render(<A />);
     expect(container.querySelector('a')).not.toBeNull();

--- a/app/components/Button/tests/StyledButton.test.js
+++ b/app/components/Button/tests/StyledButton.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { render, cleanup } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import StyledButton from '../StyledButton';
 
 describe('<StyledButton />', () => {
-  afterEach(cleanup);
-
   it('should render an <button> tag', () => {
     const { container } = render(<StyledButton />);
     expect(container.querySelector('button')).not.toBeNull();

--- a/app/components/Button/tests/Wrapper.test.js
+++ b/app/components/Button/tests/Wrapper.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { render, cleanup } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
-  afterEach(cleanup);
-
   it('should render an <div> tag', () => {
     const { container } = render(<Wrapper />);
     expect(container.querySelector('div')).not.toBeNull();

--- a/app/components/Button/tests/index.test.js
+++ b/app/components/Button/tests/index.test.js
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { cleanup, fireEvent, render } from 'react-testing-library';
+import { fireEvent, render } from 'react-testing-library';
 
 import Button from '../index';
 
@@ -18,8 +18,6 @@ const renderComponent = (props = {}) =>
   );
 
 describe('<Button />', () => {
-  afterEach(cleanup);
-
   it('should render an <a> tag if no route is specified', () => {
     const { container } = renderComponent({ href });
     expect(container.querySelector('a')).not.toBeNull();

--- a/app/components/Footer/tests/Wrapper.test.js
+++ b/app/components/Footer/tests/Wrapper.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
-  afterEach(cleanup);
-
   it('should render an <footer> tag', () => {
     const { container } = render(<Wrapper />);
     expect(container.querySelector('footer')).not.toBeNull();

--- a/app/components/H1/tests/index.test.js
+++ b/app/components/H1/tests/index.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import H1 from '../index';
 
 describe('<H1 />', () => {
-  afterEach(cleanup);
-
   it('should render a prop', () => {
     const id = 'testId';
     const { container } = render(<H1 id={id} />);

--- a/app/components/H2/tests/index.test.js
+++ b/app/components/H2/tests/index.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import H2 from '../index';
 
 describe('<H2 />', () => {
-  afterEach(cleanup);
-
   it('should render a prop', () => {
     const id = 'testId';
     const { container } = render(<H2 id={id} />);

--- a/app/components/H3/tests/index.test.js
+++ b/app/components/H3/tests/index.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import H3 from '../index';
 
 describe('<H3 />', () => {
-  afterEach(cleanup);
-
   it('should render a prop', () => {
     const id = 'testId';
     const { container } = render(<H3 id={id} />);

--- a/app/components/Header/tests/A.test.js
+++ b/app/components/Header/tests/A.test.js
@@ -1,13 +1,11 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import A from '../A';
 
 describe('<A />', () => {
-  afterEach(cleanup);
-
   it('should match the snapshot', () => {
     const renderedComponent = renderer.create(<A />).toJSON();
     expect(renderedComponent).toMatchSnapshot();

--- a/app/components/Header/tests/Img.test.js
+++ b/app/components/Header/tests/Img.test.js
@@ -1,13 +1,11 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import Img from '../Img';
 
 describe('<Img />', () => {
-  afterEach(cleanup);
-
   it('should match the snapshot', () => {
     const renderedComponent = renderer
       .create(<Img src="http://example.com/test.jpg" alt="test" />)

--- a/app/components/Header/tests/index.test.js
+++ b/app/components/Header/tests/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import { IntlProvider } from 'react-intl';
 import { ConnectedRouter } from 'connected-react-router/immutable';
@@ -11,8 +11,6 @@ import configureStore from '../../../configureStore';
 describe('<Header />', () => {
   const history = createHistory();
   const store = configureStore({}, history);
-
-  afterEach(cleanup);
 
   it('should render a div', () => {
     const { container } = render(

--- a/app/components/Img/tests/index.test.js
+++ b/app/components/Img/tests/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Img from '../index';
 
@@ -9,8 +9,6 @@ const renderComponent = (props = {}) =>
   render(<Img src={src} alt={alt} {...props} />);
 
 describe('<Img />', () => {
-  afterEach(cleanup);
-
   it('should render an <img> tag', () => {
     const { container } = renderComponent();
     const element = container.querySelector('img');

--- a/app/components/IssueIcon/tests/index.test.js
+++ b/app/components/IssueIcon/tests/index.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import IssueIcon from '../index';
 
 describe('<IssueIcon />', () => {
-  afterEach(cleanup);
-
   it('should render a SVG', () => {
     const { container } = render(<IssueIcon />);
     expect(container.querySelector('svg')).not.toBeNull();

--- a/app/components/List/tests/Ul.test.js
+++ b/app/components/List/tests/Ul.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Ul from '../Ul';
 
 describe('<Ul />', () => {
-  afterEach(cleanup);
-
   it('should render an <ul> tag', () => {
     const { container } = render(<Ul />);
     const element = container.firstElementChild;

--- a/app/components/List/tests/Wrapper.test.js
+++ b/app/components/List/tests/Wrapper.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
-  afterEach(cleanup);
-
   it('should render an <div> tag', () => {
     const { container } = render(<Wrapper />);
     expect(container.firstElementChild.tagName).toEqual('DIV');

--- a/app/components/List/tests/index.test.js
+++ b/app/components/List/tests/index.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import List from '../index';
 
 describe('<List />', () => {
-  afterEach(cleanup);
-
   it('should render the passed component if no items are passed', () => {
     const component = () => <li>test</li>; // eslint-disable-line react/prop-types
     const { container } = render(<List component={component} />);

--- a/app/components/ListItem/tests/Item.test.js
+++ b/app/components/ListItem/tests/Item.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Item from '../Item';
 
 describe('<Item />', () => {
-  afterEach(cleanup);
-
   it('should render an <div> tag', () => {
     const { container } = render(<Item />);
     expect(container.firstChild.tagName).toEqual('DIV');

--- a/app/components/ListItem/tests/Wrapper.test.js
+++ b/app/components/ListItem/tests/Wrapper.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
-  afterEach(cleanup);
-
   it('should render an <li> tag', () => {
     const { container } = render(<Wrapper />);
     const element = container.querySelector('li');

--- a/app/components/ListItem/tests/index.test.js
+++ b/app/components/ListItem/tests/index.test.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import 'jest-dom/extend-expect';
 
 import ListItem from '../index';
 
 describe('<ListItem />', () => {
-  afterEach(cleanup);
-
   it('should have a class', () => {
     const { container } = render(<ListItem className="test" />);
     expect(container.querySelector('li').hasAttribute('class')).toBe(true);

--- a/app/components/LoadingIndicator/tests/Circle.test.js
+++ b/app/components/LoadingIndicator/tests/Circle.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Circle from '../Circle';
 
 describe('<Circle />', () => {
-  afterEach(cleanup);
-
   it('should render an <div> tag', () => {
     const { container } = render(<Circle />);
     expect(container.firstChild.tagName).toEqual('DIV');

--- a/app/components/LoadingIndicator/tests/Wrapper.test.js
+++ b/app/components/LoadingIndicator/tests/Wrapper.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
-  afterEach(cleanup);
-
   it('should render an <div> tag', () => {
     const { container } = render(<Wrapper />);
     expect(container.firstElementChild.tagName).toEqual('DIV');

--- a/app/components/ReposList/tests/index.test.js
+++ b/app/components/ReposList/tests/index.test.js
@@ -2,14 +2,12 @@ import React from 'react';
 import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
 import { browserHistory } from 'react-router-dom';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import ReposList from '../index';
 import configureStore from '../../../configureStore';
 
 describe('<ReposList />', () => {
-  afterEach(cleanup);
-
   it('should render the loading indicator when its loading', () => {
     const { container } = render(<ReposList loading />);
     expect(container.firstChild).toMatchSnapshot();

--- a/app/components/Toggle/tests/Select.test.js
+++ b/app/components/Toggle/tests/Select.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Select from '../Select';
 
 describe('<Select />', () => {
-  afterEach(cleanup);
-
   it('should render an <select> tag', () => {
     const { container } = render(<Select />);
     expect(container.firstChild.tagName).toEqual('SELECT');

--- a/app/components/Toggle/tests/index.test.js
+++ b/app/components/Toggle/tests/index.test.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import { IntlProvider, defineMessages } from 'react-intl';
 
 import Toggle from '../index';
 
 describe('<Toggle />', () => {
-  afterEach(cleanup);
-
   it('should contain default text', () => {
     const defaultEnMessage = 'someContent';
     const defaultDeMessage = 'someOtherContent';

--- a/app/components/ToggleOption/tests/index.test.js
+++ b/app/components/ToggleOption/tests/index.test.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import { IntlProvider, defineMessages } from 'react-intl';
 
 import ToggleOption from '../index';
 
 describe('<ToggleOption />', () => {
-  afterEach(cleanup);
-
   it('should render default language messages', () => {
     const defaultEnMessage = 'someContent';
     const message = defineMessages({

--- a/app/containers/FeaturePage/tests/List.test.js
+++ b/app/containers/FeaturePage/tests/List.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import List from '../List';
 
 describe('<List />', () => {
-  afterEach(cleanup);
-
   it('should render an <ul> tag', () => {
     const {
       container: { firstChild },

--- a/app/containers/FeaturePage/tests/ListItem.test.js
+++ b/app/containers/FeaturePage/tests/ListItem.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import ListItem from '../ListItem';
 
 describe('<ListItem />', () => {
-  afterEach(cleanup);
-
   it('should render an <li> tag', () => {
     const {
       container: { firstChild },

--- a/app/containers/FeaturePage/tests/ListItemTitle.test.js
+++ b/app/containers/FeaturePage/tests/ListItemTitle.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import ListItemTitle from '../ListItemTitle';
 
 describe('<ListItemTitle />', () => {
-  afterEach(cleanup);
-
   it('should render an <p> tag', () => {
     const {
       container: { firstChild },

--- a/app/containers/FeaturePage/tests/index.test.js
+++ b/app/containers/FeaturePage/tests/index.test.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import { IntlProvider } from 'react-intl';
 
 import FeaturePage from '../index';
 
 describe('<FeaturePage />', () => {
-  afterEach(cleanup);
-
   it('should render its heading', () => {
     const {
       container: { firstChild },

--- a/app/containers/HomePage/tests/AtPrefix.test.js
+++ b/app/containers/HomePage/tests/AtPrefix.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import AtPrefix from '../AtPrefix';
 
 describe('<AtPrefix />', () => {
-  afterEach(cleanup);
-
   it('should render an <span> tag', () => {
     const {
       container: { firstChild },

--- a/app/containers/HomePage/tests/CenteredSection.test.js
+++ b/app/containers/HomePage/tests/CenteredSection.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import CenteredSection from '../CenteredSection';
 
 describe('<CenteredSection />', () => {
-  afterEach(cleanup);
-
   it('should render an <section> tag', () => {
     const {
       container: { firstChild },

--- a/app/containers/HomePage/tests/Form.test.js
+++ b/app/containers/HomePage/tests/Form.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Form from '../Form';
 
 describe('<Form />', () => {
-  afterEach(cleanup);
-
   it('should render an <form> tag', () => {
     const {
       container: { firstChild },

--- a/app/containers/HomePage/tests/Input.test.js
+++ b/app/containers/HomePage/tests/Input.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Input from '../Input';
 
 describe('<Input />', () => {
-  afterEach(cleanup);
-
   it('should render an <input> tag', () => {
     const { container } = render(<Input />);
     expect(container.firstChild.tagName).toEqual('INPUT');

--- a/app/containers/HomePage/tests/Section.test.js
+++ b/app/containers/HomePage/tests/Section.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Section from '../Section';
 
 describe('<Section />', () => {
-  afterEach(cleanup);
-
   it('should render an <section> tag', () => {
     const { container } = render(<Section />);
     expect(container.firstChild.tagName).toEqual('SECTION');

--- a/app/containers/HomePage/tests/index.test.js
+++ b/app/containers/HomePage/tests/index.test.js
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import { IntlProvider } from 'react-intl';
 
 import { HomePage, mapDispatchToProps } from '../index';
@@ -11,8 +11,6 @@ import { changeUsername } from '../actions';
 import { loadRepos } from '../../App/actions';
 
 describe('<HomePage />', () => {
-  afterEach(cleanup);
-
   it('should render and match the snapshot', () => {
     const {
       container: { firstChild },

--- a/app/containers/LanguageProvider/tests/index.test.js
+++ b/app/containers/LanguageProvider/tests/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { Provider } from 'react-redux';
 import { browserHistory } from 'react-router-dom';
@@ -18,8 +18,6 @@ const messages = defineMessages({
 });
 
 describe('<LanguageProvider />', () => {
-  afterEach(cleanup);
-
   it('should render its children', () => {
     const children = <h1>Test</h1>;
     const { container } = render(
@@ -37,8 +35,6 @@ describe('<ConnectedLanguageProvider />', () => {
   beforeAll(() => {
     store = configureStore({}, browserHistory);
   });
-
-  afterEach(cleanup);
 
   it('should render the default language messages', () => {
     const { queryByText } = render(

--- a/app/containers/LocaleToggle/tests/Wrapper.test.js
+++ b/app/containers/LocaleToggle/tests/Wrapper.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
-  afterEach(cleanup);
-
   it('should render an <div> tag', () => {
     const { container } = render(<Wrapper />);
     expect(container.firstChild.tagName).toEqual('DIV');

--- a/app/containers/LocaleToggle/tests/index.test.js
+++ b/app/containers/LocaleToggle/tests/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { browserHistory } from 'react-router-dom';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import LocaleToggle, { mapDispatchToProps } from '../index';
 import { changeLocale } from '../../LanguageProvider/actions';
@@ -16,8 +16,6 @@ describe('<LocaleToggle />', () => {
   beforeAll(() => {
     store = configureStore({}, browserHistory);
   });
-
-  afterEach(cleanup);
 
   it('should match the snapshot', () => {
     const { container } = render(

--- a/app/containers/NotFoundPage/tests/index.test.js
+++ b/app/containers/NotFoundPage/tests/index.test.js
@@ -3,15 +3,13 @@
  */
 
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import { IntlProvider } from 'react-intl';
 
 import NotFound from '../index';
 import messages from '../messages';
 
 describe('<NotFound />', () => {
-  afterEach(cleanup);
-
   it('should render the Page Not Found text', () => {
     const { queryByText } = render(
       <IntlProvider locale="en">

--- a/app/containers/RepoListItem/tests/IssueIcon.test.js
+++ b/app/containers/RepoListItem/tests/IssueIcon.test.js
@@ -1,13 +1,11 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import IssueIcon from '../IssueIcon';
 
 describe('<IssueIcon />', () => {
-  afterEach(cleanup);
-
   it('should match the snapshot', () => {
     const renderedComponent = renderer.create(<IssueIcon />).toJSON();
     expect(renderedComponent).toMatchSnapshot();

--- a/app/containers/RepoListItem/tests/IssueLink.test.js
+++ b/app/containers/RepoListItem/tests/IssueLink.test.js
@@ -1,13 +1,11 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import IssueLink from '../IssueLink';
 
 describe('<IssueLink />', () => {
-  afterEach(cleanup);
-
   it('should match the snapshot', () => {
     const renderedComponent = renderer.create(<IssueLink />).toJSON();
     expect(renderedComponent).toMatchSnapshot();

--- a/app/containers/RepoListItem/tests/RepoLink.test.js
+++ b/app/containers/RepoListItem/tests/RepoLink.test.js
@@ -1,13 +1,11 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import RepoLink from '../RepoLink';
 
 describe('<RepoLink />', () => {
-  afterEach(cleanup);
-
   it('should match the snapshot', () => {
     const renderedComponent = renderer.create(<RepoLink />).toJSON();
     expect(renderedComponent).toMatchSnapshot();

--- a/app/containers/RepoListItem/tests/Wrapper.test.js
+++ b/app/containers/RepoListItem/tests/Wrapper.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
 describe('<Wrapper />', () => {
-  afterEach(cleanup);
-
   it('should render an <div> tag', () => {
     const { container } = render(<Wrapper />);
     expect(container.firstChild.tagName).toEqual('DIV');

--- a/app/containers/RepoListItem/tests/index.test.js
+++ b/app/containers/RepoListItem/tests/index.test.js
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { cleanup, getByText, render } from 'react-testing-library';
+import { getByText, render } from 'react-testing-library';
 import { IntlProvider } from 'react-intl';
 
 import { RepoListItem } from '../index';
@@ -30,8 +30,6 @@ describe('<RepoListItem />', () => {
       full_name: 'react-boilerplate/react-boilerplate',
     };
   });
-
-  afterEach(cleanup);
 
   it('should render a ListItem', () => {
     const { container } = renderComponent({ item });

--- a/docs/testing/component-testing.md
+++ b/docs/testing/component-testing.md
@@ -101,7 +101,7 @@ This is our test setup:
 
 ```javascript
 import React from 'react';
-import { render, fireEvent, cleanup } from 'react-testing-library';
+import { render, fireEvent } from 'react-testing-library';
 import Button from '../Button';
 
 describe('<Button />', () => {
@@ -161,30 +161,14 @@ it('handles clicks', () => {
   expect(onClickSpy).toHaveBeenCalledTimes(1);
 });
 ```
-
-Finally, we need to cleanup after ourselves. For this react-testing-library provides us with... well... `cleanup`!
-
-We will make use of the `afterEach` method, provided by Jest, to unmount and cleanup the DOM after each finished test.
-
-```javascript
-describe('<Button />', () => {
-  afterEach(cleanup);
-});
-``` 
-
-> Failing to call `cleanup` when you've called `render` could result in a memory leak and tests which are not "idempotent"
-(which can lead to difficult to debug errors in your tests). (From the [react-testing-library documentation](https://testing-library.com/docs/react-testing-library/api#cleanup))
-
 Our finished test file looks like this:
 
 ```javascript
 import React from 'react';
-import { render, fireEvent, cleanup } from 'react-testing-library';
+import { render, fireEvent } from 'react-testing-library';
 import Button from '../Button';
 
 describe('<Button />', () => {
-  afterEach(cleanup);
-
   it('renders and matches the snapshot', () => {
     const text = 'Click me!';
     const { container } = render(<Button>{text}</Button>);

--- a/internals/generators/component/test.js.hbs
+++ b/internals/generators/component/test.js.hbs
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 {{#if wantMessages}}
 import { IntlProvider } from 'react-intl';
 {{/if}}
@@ -19,8 +19,6 @@ import { DEFAULT_LOCALE } from '../../../i18n';
 {{/if}}
 
 describe('<{{ properCase name }} />', () => {
-  afterEach(cleanup);
-
   it('Expect to not log errors in console', () => {
     const spy = jest.spyOn(global.console, 'error');
 {{#if wantMessages}}

--- a/internals/generators/container/test.js.hbs
+++ b/internals/generators/container/test.js.hbs
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 {{#if wantMessages}}
 import { IntlProvider } from 'react-intl';
 {{/if}}
@@ -19,8 +19,6 @@ import { DEFAULT_LOCALE } from '../../../i18n';
 {{/if}}
 
 describe('<{{ properCase name }} />', () => {
-  afterEach(cleanup);
-
   it('Expect to not log errors in console', () => {
     const spy = jest.spyOn(global.console, 'error');
     const dispatch = jest.fn();

--- a/internals/templates/containers/HomePage/tests/index.test.js
+++ b/internals/templates/containers/HomePage/tests/index.test.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import { IntlProvider } from 'react-intl';
 
 import HomePage from '../index';
 
 describe('<HomePage />', () => {
-  afterEach(cleanup);
-
   it('should render and match the snapshot', () => {
     const {
       container: { firstChild },

--- a/internals/templates/containers/NotFoundPage/tests/index.test.js
+++ b/internals/templates/containers/NotFoundPage/tests/index.test.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { cleanup, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 import { IntlProvider } from 'react-intl';
 
 import NotFoundPage from '../index';
 
 describe('<NotFoundPage />', () => {
-  afterEach(cleanup);
-
   it('should render and match the snapshot', () => {
     const {
       container: { firstChild },

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,7 +21,10 @@ module.exports = {
     '.*\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/internals/mocks/image.js',
   },
-  setupFilesAfterEnv: ['<rootDir>/internals/testing/test-bundler.js'],
+  setupFilesAfterEnv: [
+    '<rootDir>/internals/testing/test-bundler.js',
+    'react-testing-library/cleanup-after-each',
+  ],
   setupFiles: ['raf/polyfill'],
   testRegex: 'tests/.*\\.test\\.js$',
   snapshotSerializers: [],


### PR DESCRIPTION
## React Boilerplate

`react-testing-library` provides a `cleanup-after-each` script which can be added to Jest's `setupFilesAfterEnv` option. It means we don't need to run `cleanup` manually inside each test file.