### PR TITLE
New Webpack code-splitting config

### DIFF
--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -46,28 +46,23 @@ module.exports = require('./webpack.base.babel')({
     nodeEnv: 'production',
     sideEffects: true,
     concatenateModules: true,
+    runtimeChunk: 'single',
     splitChunks: {
       chunks: 'all',
-      minSize: 30000,
-      minChunks: 1,
-      maxAsyncRequests: 5,
-      maxInitialRequests: 3,
-      name: true,
+      maxInitialRequests: 10,
+      minSize: 0,
       cacheGroups: {
-        commons: {
+        vendor: {
           test: /[\\/]node_modules[\\/]/,
-          name: 'vendor',
-          chunks: 'all',
-        },
-        main: {
-          chunks: 'all',
-          minChunks: 2,
-          reuseExistingChunk: true,
-          enforce: true,
+          name(module) {
+            const packageName = module.context.match(
+              /[\\/]node_modules[\\/](.*?)([\\/]|$)/,
+            )[1];
+            return `npm.${packageName.replace('@', '')}`;
+          },
         },
       },
     },
-    runtimeChunk: true,
   },
 
   plugins: [


### PR DESCRIPTION
## React Boilerplate

I tested the code-splitting instructions laid out in [this article](https://hackernoon.com/the-100-correct-way-to-split-your-chunks-with-webpack-f8a9df5b7758). Here are the results of building the sample app before and after (with gzipping turned off for clarity):

Before:
![image](https://user-images.githubusercontent.com/8948127/56148603-5583da80-5fb3-11e9-8305-ed09baa84ccf.png)

After:
![image](https://user-images.githubusercontent.com/8948127/56148572-41d87400-5fb3-11e9-9748-d5a9742a0ad5.png)

As you can see, the vendor bundle is broken down into several small scripts and the entrypoint size limit warning is gone. (Perhaps because not all the vendor scripts are needed initially?) Especially for users of HTTP2, this seems like an improvement IMO.

@gretzky You wrote the current config so I'd be particularly interested in hearing your thoughts on this.