### PR TITLE
More declarative component tests using jest-dom/extend-expect

### DIFF
--- a/app/components/A/tests/index.test.js
+++ b/app/components/A/tests/index.test.js
@@ -9,44 +9,47 @@ import A from '../index';
 
 const href = 'http://mxstbr.com/';
 const children = <h1>Test</h1>;
-const renderComponent = (props = {}) =>
-  render(
+const renderComponent = (props = {}) => {
+  const utils = render(
     <A href={href} {...props}>
       {children}
     </A>,
   );
+  const link = utils.container.querySelector('a');
+  return { ...utils, link };
+};
 
 describe('<A />', () => {
   it('should render an <a> tag', () => {
-    const { container } = renderComponent();
-    expect(container.querySelector('a')).not.toBeNull();
+    const { link } = renderComponent();
+    expect(link).toBeInTheDocument();
   });
 
   it('should have an href attribute', () => {
-    const { container } = renderComponent();
-    expect(container.querySelector('a').href).toEqual(href);
+    const { link } = renderComponent();
+    expect(link).toHaveAttribute('href', href);
   });
 
   it('should have children', () => {
-    const { container } = renderComponent();
-    expect(container.querySelector('a').children).toHaveLength(1);
+    const { link } = renderComponent();
+    expect(link.children).toHaveLength(1);
   });
 
   it('should have a class attribute', () => {
     const className = 'test';
-    const { container } = renderComponent({ className });
-    expect(container.querySelector('a').classList).toContain(className);
+    const { link } = renderComponent({ className });
+    expect(link).toHaveClass(className);
   });
 
   it('should adopt a target attribute', () => {
     const target = '_blank';
-    const { container } = renderComponent({ target });
-    expect(container.querySelector('a').target).toEqual(target);
+    const { link } = renderComponent({ target });
+    expect(link).toHaveAttribute('target', target);
   });
 
   it('should adopt a type attribute', () => {
     const type = 'text/html';
-    const { container } = renderComponent({ type });
-    expect(container.querySelector('a').type).toEqual(type);
+    const { link } = renderComponent({ type });
+    expect(link).toHaveAttribute('type', type);
   });
 });

--- a/app/components/Button/tests/A.test.js
+++ b/app/components/Button/tests/A.test.js
@@ -3,25 +3,32 @@ import { render } from 'react-testing-library';
 
 import A from '../A';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<A {...props}>Link</A>);
+  const link = utils.queryByText('Link');
+  return { ...utils, link };
+};
+
 describe('<A />', () => {
   it('should render an <a> tag', () => {
-    const { container } = render(<A />);
-    expect(container.querySelector('a')).not.toBeNull();
+    const { link } = renderComponent();
+    expect(link).toBeInTheDocument();
+    expect(link.tagName).toBe('A');
   });
 
   it('should have a class attribute', () => {
-    const { container } = render(<A />);
-    expect(container.querySelector('a').hasAttribute('class')).toBe(true);
+    const { link } = renderComponent();
+    expect(link).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<A id={id} />);
-    expect(container.querySelector('a').id).toEqual(id);
+    const { link } = renderComponent({ id });
+    expect(link).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<A attribute="test" />);
-    expect(container.querySelector('a[attribute="test"]')).toBeNull();
+    const { link } = renderComponent({ attribute: 'test' });
+    expect(link).not.toHaveAttribute('attribute');
   });
 });

--- a/app/components/Button/tests/StyledButton.test.js
+++ b/app/components/Button/tests/StyledButton.test.js
@@ -3,25 +3,32 @@ import { render } from 'react-testing-library';
 
 import StyledButton from '../StyledButton';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<StyledButton {...props}>Button</StyledButton>);
+  const button = utils.queryByText('Button');
+  return { ...utils, button };
+};
+
 describe('<StyledButton />', () => {
-  it('should render an <button> tag', () => {
-    const { container } = render(<StyledButton />);
-    expect(container.querySelector('button')).not.toBeNull();
+  it('should render a <button> tag', () => {
+    const { button } = renderComponent();
+    expect(button).toBeInTheDocument();
+    expect(button.tagName).toBe('BUTTON');
   });
 
   it('should have a class attribute', () => {
-    const { container } = render(<StyledButton />);
-    expect(container.querySelector('button').hasAttribute('class')).toBe(true);
+    const { button } = renderComponent();
+    expect(button).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<StyledButton id={id} />);
-    expect(container.querySelector('button').id).toEqual(id);
+    const { button } = renderComponent({ id });
+    expect(button).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<StyledButton attribute="test" />);
-    expect(container.querySelector('button[attribute="test"]')).toBeNull();
+    const { button } = renderComponent({ attribute: 'test' });
+    expect(button).not.toHaveAttribute('attribute');
   });
 });

--- a/app/components/Button/tests/Wrapper.test.js
+++ b/app/components/Button/tests/Wrapper.test.js
@@ -3,25 +3,32 @@ import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<Wrapper {...props}>Wrapper</Wrapper>);
+  const wrapper = utils.queryByText('Wrapper');
+  return { ...utils, wrapper };
+};
+
 describe('<Wrapper />', () => {
-  it('should render an <div> tag', () => {
-    const { container } = render(<Wrapper />);
-    expect(container.querySelector('div')).not.toBeNull();
+  it('should render a <div> tag', () => {
+    const { wrapper } = renderComponent();
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper.tagName).toBe('DIV');
   });
 
   it('should have a class attribute', () => {
-    const { container } = render(<Wrapper />);
-    expect(container.querySelector('div').hasAttribute('class')).toBe(true);
+    const { wrapper } = renderComponent();
+    expect(wrapper).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<Wrapper id={id} />);
-    expect(container.querySelector('div').id).toEqual(id);
+    const { wrapper } = renderComponent({ id });
+    expect(wrapper).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<Wrapper attribute="test" />);
-    expect(container.querySelector('div[attribute="test"]')).toBeNull();
+    const { wrapper } = renderComponent({ attribute: 'test' });
+    expect(wrapper).not.toHaveAttribute('attribute');
   });
 });

--- a/app/components/Button/tests/index.test.js
+++ b/app/components/Button/tests/index.test.js
@@ -10,50 +10,54 @@ import Button from '../index';
 const handleRoute = () => {};
 const href = 'http://mxstbr.com';
 const children = <h1>Test</h1>;
-const renderComponent = (props = {}) =>
-  render(
+const renderComponent = (props = {}) => {
+  const utils = render(
     <Button href={href} {...props}>
       {children}
     </Button>,
   );
 
+  const button = utils.queryByText('Test').parentNode;
+  return { ...utils, button };
+};
+
 describe('<Button />', () => {
   it('should render an <a> tag if no route is specified', () => {
-    const { container } = renderComponent({ href });
-    expect(container.querySelector('a')).not.toBeNull();
+    const { button } = renderComponent({ href });
+    expect(button.tagName).toBe('A');
   });
 
   it('should render a <button> tag to change route if the handleRoute prop is specified', () => {
-    const { container } = renderComponent({ handleRoute });
-    expect(container.querySelector('button')).toBeDefined();
+    const { button } = renderComponent({ handleRoute });
+    expect(button.tagName).toBe('BUTTON');
   });
 
   it('should have children', () => {
-    const { container } = renderComponent();
-    expect(container.querySelector('a').children).toHaveLength(1);
+    const { button } = renderComponent();
+    expect(button.children).toHaveLength(1);
   });
 
   it('should handle click events', () => {
     const onClickSpy = jest.fn();
-    const { container } = renderComponent({ onClick: onClickSpy });
-    fireEvent.click(container.querySelector('a'));
+    const { button } = renderComponent({ onClick: onClickSpy });
+    fireEvent.click(button);
     expect(onClickSpy).toHaveBeenCalled();
   });
 
   it('should have a class attribute', () => {
-    const { container } = renderComponent();
-    expect(container.querySelector('a').hasAttribute('class')).toBe(true);
+    const { button } = renderComponent();
+    expect(button).toHaveAttribute('class');
   });
 
   it('should not adopt a type attribute when rendering an <a> tag', () => {
     const type = 'text/html';
-    const { container } = renderComponent({ href, type });
-    expect(container.querySelector(`a[type="${type}"]`)).toBeNull();
+    const { button } = renderComponent({ href, type });
+    expect(button).not.toHaveAttribute('type');
   });
 
   it('should not adopt a type attribute when rendering a button', () => {
     const type = 'submit';
-    const { container } = renderComponent({ handleRoute, type });
-    expect(container.querySelector('button').getAttribute('type')).toBeNull();
+    const { button } = renderComponent({ handleRoute, type });
+    expect(button).not.toHaveAttribute('type');
   });
 });

--- a/app/components/Footer/tests/Wrapper.test.js
+++ b/app/components/Footer/tests/Wrapper.test.js
@@ -3,27 +3,32 @@ import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<Wrapper {...props}>Wrapper</Wrapper>);
+  const wrapper = utils.queryByText('Wrapper');
+  return { ...utils, wrapper };
+};
+
 describe('<Wrapper />', () => {
-  it('should render an <footer> tag', () => {
-    const { container } = render(<Wrapper />);
-    expect(container.querySelector('footer')).not.toBeNull();
+  it('should render a <footer> tag', () => {
+    const { wrapper } = renderComponent();
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper.tagName).toBe('FOOTER');
   });
 
   it('should have a class attribute', () => {
-    const { container } = render(<Wrapper />);
-    expect(container.querySelector('footer').hasAttribute('class')).toBe(true);
+    const { wrapper } = renderComponent();
+    expect(wrapper).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<Wrapper id={id} />);
-    expect(container.querySelector('footer').id).toEqual(id);
+    const { wrapper } = renderComponent({ id });
+    expect(wrapper).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<Wrapper attribute="test" />);
-    expect(
-      container.querySelector('footer').getAttribute('attribute'),
-    ).toBeNull();
+    const { wrapper } = renderComponent({ attribute: 'test' });
+    expect(wrapper).not.toHaveAttribute('attribute');
   });
 });

--- a/app/components/H1/tests/index.test.js
+++ b/app/components/H1/tests/index.test.js
@@ -3,18 +3,22 @@ import { render } from 'react-testing-library';
 
 import H1 from '../index';
 
+const children = 'Text';
+const renderComponent = (props = {}) => {
+  const utils = render(<H1 {...props}>{children}</H1>);
+  const heading = utils.queryByText(children);
+  return { ...utils, heading };
+};
+
 describe('<H1 />', () => {
   it('should render a prop', () => {
-    const id = 'testId';
-    const { container } = render(<H1 id={id} />);
-    expect(container.querySelector('h1').id).toEqual(id);
+    const id = 'test';
+    const { heading } = renderComponent({ id });
+    expect(heading).toHaveAttribute('id', id);
   });
 
   it('should render its text', () => {
-    const children = 'Text';
-    const { container, queryByText } = render(<H1>{children}</H1>);
-    const { childNodes } = container.querySelector('h1');
-    expect(childNodes).toHaveLength(1);
-    expect(queryByText(children)).not.toBeNull();
+    const { heading } = renderComponent();
+    expect(heading).toHaveTextContent(children);
   });
 });

--- a/app/components/H2/tests/index.test.js
+++ b/app/components/H2/tests/index.test.js
@@ -3,18 +3,22 @@ import { render } from 'react-testing-library';
 
 import H2 from '../index';
 
+const children = 'Text';
+const renderComponent = (props = {}) => {
+  const utils = render(<H2 {...props}>{children}</H2>);
+  const heading = utils.queryByText(children);
+  return { ...utils, heading };
+};
+
 describe('<H2 />', () => {
   it('should render a prop', () => {
-    const id = 'testId';
-    const { container } = render(<H2 id={id} />);
-    expect(container.querySelector('h2').id).toEqual(id);
+    const id = 'test';
+    const { heading } = renderComponent({ id });
+    expect(heading).toHaveAttribute('id', id);
   });
 
   it('should render its text', () => {
-    const children = 'Text';
-    const { container, queryByText } = render(<H2>{children}</H2>);
-    const { childNodes } = container.querySelector('h2');
-    expect(childNodes).toHaveLength(1);
-    expect(queryByText(children)).not.toBeNull();
+    const { heading } = renderComponent();
+    expect(heading).toHaveTextContent(children);
   });
 });

--- a/app/components/H3/tests/index.test.js
+++ b/app/components/H3/tests/index.test.js
@@ -3,18 +3,22 @@ import { render } from 'react-testing-library';
 
 import H3 from '../index';
 
+const children = 'Text';
+const renderComponent = (props = {}) => {
+  const utils = render(<H3 {...props}>{children}</H3>);
+  const heading = utils.queryByText(children);
+  return { ...utils, heading };
+};
+
 describe('<H3 />', () => {
   it('should render a prop', () => {
-    const id = 'testId';
-    const { container } = render(<H3 id={id} />);
-    expect(container.querySelector('h3').id).toEqual(id);
+    const id = 'test';
+    const { heading } = renderComponent({ id });
+    expect(heading).toHaveAttribute('id', id);
   });
 
   it('should render its text', () => {
-    const children = 'Text';
-    const { container, queryByText } = render(<H3>{children}</H3>);
-    const { childNodes } = container.querySelector('h3');
-    expect(childNodes).toHaveLength(1);
-    expect(queryByText(children)).not.toBeNull();
+    const { heading } = renderComponent();
+    expect(heading).toHaveTextContent(children);
   });
 });

--- a/app/components/Header/tests/A.test.js
+++ b/app/components/Header/tests/A.test.js
@@ -1,29 +1,34 @@
 import React from 'react';
 import { render } from 'react-testing-library';
-import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import A from '../A';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<A {...props}>Link</A>);
+  const link = utils.queryByText('Link');
+  return { ...utils, link };
+};
+
 describe('<A />', () => {
   it('should match the snapshot', () => {
-    const renderedComponent = renderer.create(<A />).toJSON();
-    expect(renderedComponent).toMatchSnapshot();
+    const { container } = renderComponent();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should have a class attribute', () => {
-    const { container } = render(<A />);
-    expect(container.querySelector('a').hasAttribute('class')).toBe(true);
+    const { link } = renderComponent();
+    expect(link).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<A id={id} />);
-    expect(container.querySelector('a').id).toEqual(id);
+    const { link } = renderComponent({ id });
+    expect(link).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<A attribute="test" />);
-    expect(container.querySelector('a').getAttribute('attribute')).toBeNull();
+    const { link } = renderComponent({ attribute: 'test' });
+    expect(link).not.toHaveAttribute('attribute');
   });
 });

--- a/app/components/Header/tests/Img.test.js
+++ b/app/components/Header/tests/Img.test.js
@@ -1,36 +1,31 @@
 import React from 'react';
 import { render } from 'react-testing-library';
-import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import Img from '../Img';
 
+const alt = 'test';
+const renderComponent = (props = {}) => {
+  const utils = render(
+    <Img src="http://example.com/test.jpg" alt={alt} {...props} />,
+  );
+  const image = utils.queryByAltText(alt);
+  return { ...utils, image };
+};
+
 describe('<Img />', () => {
   it('should match the snapshot', () => {
-    const renderedComponent = renderer
-      .create(<Img src="http://example.com/test.jpg" alt="test" />)
-      .toJSON();
-    expect(renderedComponent).toMatchSnapshot();
+    const { container } = renderComponent();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should have a class attribute', () => {
-    const { container } = render(
-      <Img src="http://example.com/test.jpg" alt="test" />,
-    );
-    expect(container.querySelector('img').hasAttribute('class')).toBe(true);
-  });
-
-  it('should adopt a valid attribute', () => {
-    const { container } = render(
-      <Img src="http://example.com/test.jpg" alt="test" />,
-    );
-    expect(container.querySelector('img').alt).toEqual('test');
+    const { image } = renderComponent();
+    expect(image).toHaveAttribute('class');
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(
-      <Img src="http://example.com/test.jpg" attribute="test" alt="test" />,
-    );
-    expect(container.querySelector('img').getAttribute('attribute')).toBeNull();
+    const { image } = renderComponent({ attribute: 'test' });
+    expect(image).not.toHaveAttribute('attribute');
   });
 });

--- a/app/components/Header/tests/__snapshots__/A.test.js.snap
+++ b/app/components/Header/tests/__snapshots__/A.test.js.snap
@@ -11,6 +11,8 @@ exports[`<A /> should match the snapshot 1`] = `
 }
 
 <a
-  className="c0"
-/>
+  class="c0"
+>
+  Link
+</a>
 `;

--- a/app/components/Header/tests/__snapshots__/Img.test.js.snap
+++ b/app/components/Header/tests/__snapshots__/Img.test.js.snap
@@ -9,7 +9,7 @@ exports[`<Img /> should match the snapshot 1`] = `
 
 <img
   alt="test"
-  className="c0"
+  class="c0"
   src="http://example.com/test.jpg"
 />
 `;

--- a/app/components/Img/tests/index.test.js
+++ b/app/components/Img/tests/index.test.js
@@ -19,12 +19,12 @@ describe('<Img />', () => {
   });
 
   it('should throw when no alt attribute is specified', () => {
-    jest.spyOn(console, 'error').mockImplementation(() => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {
       /* noop */
     });
     render(<Img src={src} />);
-    expect(console.error).toHaveBeenCalledTimes(1);
-    console.error.mockRestore();
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    consoleSpy.mockRestore();
   });
 
   it('should have a src attribute', () => {

--- a/app/components/Img/tests/index.test.js
+++ b/app/components/Img/tests/index.test.js
@@ -5,45 +5,47 @@ import Img from '../index';
 
 const src = 'test.png';
 const alt = 'test';
-const renderComponent = (props = {}) =>
-  render(<Img src={src} alt={alt} {...props} />);
+const renderComponent = (props = {}) => {
+  const utils = render(<Img src={src} alt={alt} {...props} />);
+  const image = utils.queryByAltText(alt);
+  return { ...utils, image };
+};
 
 describe('<Img />', () => {
   it('should render an <img> tag', () => {
-    const { container } = renderComponent();
-    const element = container.querySelector('img');
-    expect(element).not.toBeNull();
+    const { image } = renderComponent();
+    expect(image).toBeInTheDocument();
+    expect(image.tagName).toBe('IMG');
   });
 
-  it('should have an src attribute', () => {
-    const { container } = renderComponent();
-    const element = container.querySelector('img');
-    expect(element.hasAttribute('src')).toBe(true);
+  it('should throw when no alt attribute is specified', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {
+      /* noop */
+    });
+    render(<Img src={src} />);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    console.error.mockRestore();
   });
 
-  it('should have an alt attribute', () => {
-    const { container } = renderComponent();
-    const element = container.querySelector('img');
-    expect(element.hasAttribute('alt')).toBe(true);
+  it('should have a src attribute', () => {
+    const { image } = renderComponent();
+    expect(image).toHaveAttribute('src', src);
   });
 
   it('should not have a class attribute', () => {
-    const { container } = renderComponent();
-    const element = container.querySelector('img');
-    expect(element.hasAttribute('class')).toBe(false);
+    const { image } = renderComponent();
+    expect(image).not.toHaveAttribute('class');
   });
 
   it('should adopt a className attribute', () => {
     const className = 'test';
-    const { container } = renderComponent({ className });
-    const element = container.querySelector('img');
-    expect(element.className).toEqual(className);
+    const { image } = renderComponent({ className });
+    expect(image).toHaveClass(className);
   });
 
   it('should not adopt a srcset attribute', () => {
     const srcset = 'test-HD.png 2x';
-    const { container } = renderComponent({ srcset });
-    const element = container.querySelector('img');
-    expect(element.hasAttribute('srcset')).toBe(false);
+    const { image } = renderComponent({ srcset });
+    expect(image).not.toHaveAttribute('srcset');
   });
 });

--- a/app/components/IssueIcon/tests/index.test.js
+++ b/app/components/IssueIcon/tests/index.test.js
@@ -5,7 +5,9 @@ import IssueIcon from '../index';
 
 describe('<IssueIcon />', () => {
   it('should render a SVG', () => {
-    const { container } = render(<IssueIcon />);
-    expect(container.querySelector('svg')).not.toBeNull();
+    const { queryByTestId } = render(<IssueIcon data-testid="svg" />);
+    const element = queryByTestId('svg');
+    expect(element).toBeInTheDocument();
+    expect(element.tagName).toBe('svg');
   });
 });

--- a/app/components/List/tests/Ul.test.js
+++ b/app/components/List/tests/Ul.test.js
@@ -3,29 +3,33 @@ import { render } from 'react-testing-library';
 
 import Ul from '../Ul';
 
+const testId = 'list';
+const renderComponent = (props = {}) => {
+  const utils = render(<Ul {...props} data-testid={testId} />);
+  const list = utils.queryByTestId(testId);
+  return { ...utils, list };
+};
+
 describe('<Ul />', () => {
-  it('should render an <ul> tag', () => {
-    const { container } = render(<Ul />);
-    const element = container.firstElementChild;
-    expect(element.tagName).toEqual('UL');
+  it('should render a <ul> tag', () => {
+    const { list } = renderComponent();
+    expect(list).toBeInTheDocument();
+    expect(list.tagName).toBe('UL');
   });
 
   it('should have a class attribute', () => {
-    const { container } = render(<Ul />);
-    const element = container.firstElementChild;
-    expect(element.hasAttribute('class')).toBe(true);
+    const { list } = renderComponent();
+    expect(list).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<Ul id={id} />);
-    const element = container.firstElementChild;
-    expect(element.id).toEqual(id);
+    const { list } = renderComponent({ id });
+    expect(list).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<Ul attribute="test" />);
-    const element = container.firstElementChild;
-    expect(element.hasAttribute('attribute')).toBe(false);
+    const { list } = renderComponent({ attribute: 'test' });
+    expect(list).not.toHaveAttribute('attribute');
   });
 });

--- a/app/components/List/tests/Wrapper.test.js
+++ b/app/components/List/tests/Wrapper.test.js
@@ -3,28 +3,32 @@ import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<Wrapper {...props}>Wrapper</Wrapper>);
+  const wrapper = utils.queryByText('Wrapper');
+  return { ...utils, wrapper };
+};
+
 describe('<Wrapper />', () => {
-  it('should render an <div> tag', () => {
-    const { container } = render(<Wrapper />);
-    expect(container.firstElementChild.tagName).toEqual('DIV');
+  it('should render a <div> tag', () => {
+    const { wrapper } = renderComponent();
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper.tagName).toBe('DIV');
   });
 
   it('should have a class attribute', () => {
-    const { container } = render(<Wrapper />);
-    const element = container.firstElementChild;
-    expect(element.hasAttribute('class')).toBe(true);
+    const { wrapper } = renderComponent();
+    expect(wrapper).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<Wrapper id={id} />);
-    const element = container.firstElementChild;
-    expect(element.id).toEqual(id);
+    const { wrapper } = renderComponent({ id });
+    expect(wrapper).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<Wrapper attribute="test" />);
-    const element = container.firstElementChild;
-    expect(element.hasAttribute('attribute')).toBe(false);
+    const { wrapper } = renderComponent({ attribute: 'test' });
+    expect(wrapper).not.toHaveAttribute('attribute');
   });
 });

--- a/app/components/List/tests/index.test.js
+++ b/app/components/List/tests/index.test.js
@@ -6,8 +6,8 @@ import List from '../index';
 describe('<List />', () => {
   it('should render the passed component if no items are passed', () => {
     const component = () => <li>test</li>; // eslint-disable-line react/prop-types
-    const { container } = render(<List component={component} />);
-    expect(container.querySelector('li')).not.toBeNull();
+    const { queryByText } = render(<List component={component} />);
+    expect(queryByText('test')).toBeInTheDocument();
   });
 
   it('should pass all items props to rendered component', () => {
@@ -15,12 +15,12 @@ describe('<List />', () => {
 
     const component = ({ item }) => <li>{item.name}</li>; // eslint-disable-line react/prop-types
 
-    const { container, getByText } = render(
+    const { container, queryByText } = render(
       <List items={items} component={component} />,
     );
     const elements = container.querySelectorAll('li');
     expect(elements).toHaveLength(2);
-    expect(getByText(items[0].name)).not.toBeNull();
-    expect(getByText(items[1].name)).not.toBeNull();
+    expect(queryByText(items[0].name)).toBeInTheDocument();
+    expect(queryByText(items[1].name)).toBeInTheDocument();
   });
 });

--- a/app/components/LoadingIndicator/tests/Circle.test.js
+++ b/app/components/LoadingIndicator/tests/Circle.test.js
@@ -4,19 +4,19 @@ import { render } from 'react-testing-library';
 import Circle from '../Circle';
 
 describe('<Circle />', () => {
-  it('should render an <div> tag', () => {
+  it('should render a <div> tag', () => {
     const { container } = render(<Circle />);
     expect(container.firstChild.tagName).toEqual('DIV');
   });
 
   it('should have a class attribute', () => {
     const { container } = render(<Circle />);
-    expect(container.firstChild.hasAttribute('class')).toBe(true);
+    expect(container.firstChild).toHaveAttribute('class');
   });
 
   it('should not adopt attributes', () => {
     const id = 'test';
     const { container } = render(<Circle id={id} />);
-    expect(container.firstChild.hasAttribute('id')).toBe(false);
+    expect(container.firstChild).not.toHaveAttribute('id');
   });
 });

--- a/app/components/LoadingIndicator/tests/Wrapper.test.js
+++ b/app/components/LoadingIndicator/tests/Wrapper.test.js
@@ -3,28 +3,32 @@ import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<Wrapper {...props}>Wrapper</Wrapper>);
+  const wrapper = utils.queryByText('Wrapper');
+  return { ...utils, wrapper };
+};
+
 describe('<Wrapper />', () => {
-  it('should render an <div> tag', () => {
-    const { container } = render(<Wrapper />);
-    expect(container.firstElementChild.tagName).toEqual('DIV');
+  it('should render a <div> tag', () => {
+    const { wrapper } = renderComponent();
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper.tagName).toBe('DIV');
   });
 
   it('should have a class attribute', () => {
-    const { container } = render(<Wrapper />);
-    const element = container.firstElementChild;
-    expect(element.hasAttribute('class')).toBe(true);
+    const { wrapper } = renderComponent();
+    expect(wrapper).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<Wrapper id={id} />);
-    const element = container.firstElementChild;
-    expect(element.id).toEqual(id);
+    const { wrapper } = renderComponent({ id });
+    expect(wrapper).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<Wrapper attribute="test" />);
-    const element = container.firstElementChild;
-    expect(element.hasAttribute('attribute')).toBe(false);
+    const { wrapper } = renderComponent({ attribute: 'test' });
+    expect(wrapper).not.toHaveAttribute('attribute');
   });
 });

--- a/app/components/LoadingIndicator/tests/__snapshots__/index.test.js.snap
+++ b/app/components/LoadingIndicator/tests/__snapshots__/index.test.js.snap
@@ -337,43 +337,43 @@ exports[`<LoadingIndicator /> should match the snapshot 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="c7"
+    class="c7"
   />
   <div
-    className="c8"
+    class="c8"
   />
   <div
-    className="c9"
+    class="c9"
   />
   <div
-    className="c10"
+    class="c10"
   />
   <div
-    className="c11"
+    class="c11"
   />
   <div
-    className="c12"
+    class="c12"
   />
 </div>
 `;

--- a/app/components/LoadingIndicator/tests/index.test.js
+++ b/app/components/LoadingIndicator/tests/index.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from 'react-testing-library';
 import 'jest-styled-components';
 
 import LoadingIndicator from '../index';
 
 describe('<LoadingIndicator />', () => {
   it('should match the snapshot', () => {
-    const renderedComponent = renderer.create(<LoadingIndicator />).toJSON();
-    expect(renderedComponent).toMatchSnapshot();
+    const { container } = render(<LoadingIndicator />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/app/components/ReposList/tests/index.test.js
+++ b/app/components/ReposList/tests/index.test.js
@@ -19,7 +19,7 @@ describe('<ReposList />', () => {
         <ReposList loading={false} error={{ message: 'Loading failed!' }} />
       </IntlProvider>,
     );
-    expect(queryByText(/Something went wrong/)).not.toBeNull();
+    expect(queryByText(/Something went wrong/)).toBeInTheDocument();
   });
 
   it('should render the repositories if loading was successful', () => {
@@ -54,6 +54,6 @@ describe('<ReposList />', () => {
       <ReposList repos={false} error={false} loading={false} />,
     );
 
-    expect(container.firstChild).toBeNull();
+    expect(container).toBeEmpty();
   });
 });

--- a/app/components/Toggle/tests/Select.test.js
+++ b/app/components/Toggle/tests/Select.test.js
@@ -11,17 +11,17 @@ describe('<Select />', () => {
 
   it('should have a class attribute', () => {
     const { container } = render(<Select />);
-    expect(container.firstChild.hasAttribute('class')).toBe(true);
+    expect(container.firstChild).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
     const { container } = render(<Select id={id} />);
-    expect(container.firstChild.id).toEqual(id);
+    expect(container.firstChild).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
     const { container } = render(<Select attribute="test" />);
-    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
+    expect(container.firstChild).not.toHaveAttribute('attribute');
   });
 });

--- a/app/components/Toggle/tests/index.test.js
+++ b/app/components/Toggle/tests/index.test.js
@@ -30,6 +30,6 @@ describe('<Toggle />', () => {
     const { container } = render(<Toggle />);
     const elements = container.querySelectorAll('option');
     expect(elements).toHaveLength(1);
-    expect(container.firstChild.value).toEqual('--');
+    expect(container.firstChild).toHaveTextContent('--');
   });
 });

--- a/app/components/ToggleOption/tests/index.test.js
+++ b/app/components/ToggleOption/tests/index.test.js
@@ -27,6 +27,6 @@ describe('<ToggleOption />', () => {
         <ToggleOption value="de" />
       </IntlProvider>,
     );
-    expect(queryByText('de')).toBeDefined();
+    expect(queryByText('de')).toBeInTheDocument();
   });
 });

--- a/app/containers/FeaturePage/tests/List.test.js
+++ b/app/containers/FeaturePage/tests/List.test.js
@@ -3,33 +3,32 @@ import { render } from 'react-testing-library';
 
 import List from '../List';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<List {...props} />);
+  const element = utils.container.firstChild;
+  return { ...utils, element };
+};
+
 describe('<List />', () => {
   it('should render an <ul> tag', () => {
-    const {
-      container: { firstChild },
-    } = render(<List />);
-    expect(firstChild.tagName).toEqual('UL');
+    const { element } = renderComponent();
+    expect(element).toBeInTheDocument();
+    expect(element.tagName).toEqual('UL');
   });
 
   it('should have a class attribute', () => {
-    const {
-      container: { firstChild },
-    } = render(<List />);
-    expect(firstChild.hasAttribute('class')).toBe(true);
+    const { element } = renderComponent();
+    expect(element).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const {
-      container: { firstChild },
-    } = render(<List id={id} />);
-    expect(firstChild.id).toEqual(id);
+    const { element } = renderComponent({ id });
+    expect(element).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const {
-      container: { firstChild },
-    } = render(<List attribute="test" />);
-    expect(firstChild.hasAttribute('attribute')).toBe(false);
+    const { element } = renderComponent({ attribute: 'test' });
+    expect(element).not.toHaveAttribute('attribute');
   });
 });

--- a/app/containers/FeaturePage/tests/ListItem.test.js
+++ b/app/containers/FeaturePage/tests/ListItem.test.js
@@ -3,33 +3,32 @@ import { render } from 'react-testing-library';
 
 import ListItem from '../ListItem';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<ListItem {...props} />);
+  const element = utils.container.firstChild;
+  return { ...utils, element };
+};
+
 describe('<ListItem />', () => {
   it('should render an <li> tag', () => {
-    const {
-      container: { firstChild },
-    } = render(<ListItem />);
-    expect(firstChild.tagName).toEqual('LI');
+    const { element } = renderComponent();
+    expect(element).toBeInTheDocument();
+    expect(element.tagName).toEqual('LI');
   });
 
   it('should have a class attribute', () => {
-    const {
-      container: { firstChild },
-    } = render(<ListItem />);
-    expect(firstChild.hasAttribute('class')).toBe(true);
+    const { element } = renderComponent();
+    expect(element).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const {
-      container: { firstChild },
-    } = render(<ListItem id={id} />);
-    expect(firstChild.id).toEqual(id);
+    const { element } = renderComponent({ id });
+    expect(element).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const {
-      container: { firstChild },
-    } = render(<ListItem attribute="test" />);
-    expect(firstChild.hasAttribute('attribute')).toBe(false);
+    const { element } = renderComponent({ attribute: 'test' });
+    expect(element).not.toHaveAttribute('attribute');
   });
 });

--- a/app/containers/FeaturePage/tests/ListItemTitle.test.js
+++ b/app/containers/FeaturePage/tests/ListItemTitle.test.js
@@ -3,33 +3,32 @@ import { render } from 'react-testing-library';
 
 import ListItemTitle from '../ListItemTitle';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<ListItemTitle {...props} />);
+  const element = utils.container.firstChild;
+  return { ...utils, element };
+};
+
 describe('<ListItemTitle />', () => {
   it('should render an <p> tag', () => {
-    const {
-      container: { firstChild },
-    } = render(<ListItemTitle />);
-    expect(firstChild.tagName).toEqual('P');
+    const { element } = renderComponent();
+    expect(element).toBeInTheDocument();
+    expect(element.tagName).toEqual('P');
   });
 
   it('should have a class attribute', () => {
-    const {
-      container: { firstChild },
-    } = render(<ListItemTitle />);
-    expect(firstChild.hasAttribute('class')).toBe(true);
+    const { element } = renderComponent();
+    expect(element).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const {
-      container: { firstChild },
-    } = render(<ListItemTitle id={id} />);
-    expect(firstChild.id).toEqual(id);
+    const { element } = renderComponent({ id });
+    expect(element).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const {
-      container: { firstChild },
-    } = render(<ListItemTitle attribute="test" />);
-    expect(firstChild.hasAttribute('attribute')).toBe(false);
+    const { element } = renderComponent({ attribute: 'test' });
+    expect(element).not.toHaveAttribute('attribute');
   });
 });

--- a/app/containers/HomePage/tests/AtPrefix.test.js
+++ b/app/containers/HomePage/tests/AtPrefix.test.js
@@ -3,33 +3,32 @@ import { render } from 'react-testing-library';
 
 import AtPrefix from '../AtPrefix';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<AtPrefix {...props} />);
+  const element = utils.container.firstChild;
+  return { ...utils, element };
+};
+
 describe('<AtPrefix />', () => {
-  it('should render an <span> tag', () => {
-    const {
-      container: { firstChild },
-    } = render(<AtPrefix />);
-    expect(firstChild.tagName).toEqual('SPAN');
+  it('should render a <span> tag', () => {
+    const { element } = renderComponent();
+    expect(element).toBeInTheDocument();
+    expect(element.tagName).toEqual('SPAN');
   });
 
   it('should have a class attribute', () => {
-    const {
-      container: { firstChild },
-    } = render(<AtPrefix />);
-    expect(firstChild.hasAttribute('class')).toBe(true);
+    const { element } = renderComponent();
+    expect(element).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const {
-      container: { firstChild },
-    } = render(<AtPrefix id={id} />);
-    expect(firstChild.id).toEqual(id);
+    const { element } = renderComponent({ id });
+    expect(element).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const {
-      container: { firstChild },
-    } = render(<AtPrefix attribute="test" />);
-    expect(firstChild.hasAttribute('attribute')).toBe(false);
+    const { element } = renderComponent({ attribute: 'test' });
+    expect(element).not.toHaveAttribute('attribute');
   });
 });

--- a/app/containers/HomePage/tests/CenteredSection.test.js
+++ b/app/containers/HomePage/tests/CenteredSection.test.js
@@ -3,33 +3,32 @@ import { render } from 'react-testing-library';
 
 import CenteredSection from '../CenteredSection';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<CenteredSection {...props} />);
+  const element = utils.container.firstChild;
+  return { ...utils, element };
+};
+
 describe('<CenteredSection />', () => {
-  it('should render an <section> tag', () => {
-    const {
-      container: { firstChild },
-    } = render(<CenteredSection />);
-    expect(firstChild.tagName).toEqual('SECTION');
+  it('should render a <section> tag', () => {
+    const { element } = renderComponent();
+    expect(element).toBeInTheDocument();
+    expect(element.tagName).toEqual('SECTION');
   });
 
   it('should have a class attribute', () => {
-    const {
-      container: { firstChild },
-    } = render(<CenteredSection />);
-    expect(firstChild.hasAttribute('class')).toBe(true);
+    const { element } = renderComponent();
+    expect(element).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const {
-      container: { firstChild },
-    } = render(<CenteredSection id={id} />);
-    expect(firstChild.id).toEqual(id);
+    const { element } = renderComponent({ id });
+    expect(element).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const {
-      container: { firstChild },
-    } = render(<CenteredSection attribute="test" />);
-    expect(firstChild.hasAttribute('attribute')).toBe(false);
+    const { element } = renderComponent({ attribute: 'test' });
+    expect(element).not.toHaveAttribute('attribute');
   });
 });

--- a/app/containers/HomePage/tests/Form.test.js
+++ b/app/containers/HomePage/tests/Form.test.js
@@ -3,33 +3,32 @@ import { render } from 'react-testing-library';
 
 import Form from '../Form';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<Form {...props} />);
+  const element = utils.container.firstChild;
+  return { ...utils, element };
+};
+
 describe('<Form />', () => {
-  it('should render an <form> tag', () => {
-    const {
-      container: { firstChild },
-    } = render(<Form />);
-    expect(firstChild.tagName).toEqual('FORM');
+  it('should render a <form> tag', () => {
+    const { element } = renderComponent();
+    expect(element).toBeInTheDocument();
+    expect(element.tagName).toEqual('FORM');
   });
 
   it('should have a class attribute', () => {
-    const {
-      container: { firstChild },
-    } = render(<Form />);
-    expect(firstChild.hasAttribute('class')).toBe(true);
+    const { element } = renderComponent();
+    expect(element).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const {
-      container: { firstChild },
-    } = render(<Form id={id} />);
-    expect(firstChild.id).toEqual(id);
+    const { element } = renderComponent({ id });
+    expect(element).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const {
-      container: { firstChild },
-    } = render(<Form attribute="test" />);
-    expect(firstChild.hasAttribute('attribute')).toBe(false);
+    const { element } = renderComponent({ attribute: 'test' });
+    expect(element).not.toHaveAttribute('attribute');
   });
 });

--- a/app/containers/HomePage/tests/Input.test.js
+++ b/app/containers/HomePage/tests/Input.test.js
@@ -3,25 +3,32 @@ import { render } from 'react-testing-library';
 
 import Input from '../Input';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<Input {...props} />);
+  const element = utils.container.firstChild;
+  return { ...utils, element };
+};
+
 describe('<Input />', () => {
-  it('should render an <input> tag', () => {
-    const { container } = render(<Input />);
-    expect(container.firstChild.tagName).toEqual('INPUT');
+  it('should render a <input> tag', () => {
+    const { element } = renderComponent();
+    expect(element).toBeInTheDocument();
+    expect(element.tagName).toEqual('INPUT');
   });
 
   it('should have a class attribute', () => {
-    const { container } = render(<Input />);
-    expect(container.firstChild.hasAttribute('class')).toBe(true);
+    const { element } = renderComponent();
+    expect(element).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<Input id={id} />);
-    expect(container.firstChild.id).toEqual(id);
+    const { element } = renderComponent({ id });
+    expect(element).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<Input attribute="test" />);
-    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
+    const { element } = renderComponent({ attribute: 'test' });
+    expect(element).not.toHaveAttribute('attribute');
   });
 });

--- a/app/containers/HomePage/tests/Section.test.js
+++ b/app/containers/HomePage/tests/Section.test.js
@@ -3,25 +3,32 @@ import { render } from 'react-testing-library';
 
 import Section from '../Section';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<Section {...props} />);
+  const element = utils.container.firstChild;
+  return { ...utils, element };
+};
+
 describe('<Section />', () => {
-  it('should render an <section> tag', () => {
-    const { container } = render(<Section />);
-    expect(container.firstChild.tagName).toEqual('SECTION');
+  it('should render a <section> tag', () => {
+    const { element } = renderComponent();
+    expect(element).toBeInTheDocument();
+    expect(element.tagName).toEqual('SECTION');
   });
 
   it('should have a class attribute', () => {
-    const { container } = render(<Section />);
-    expect(container.firstChild.hasAttribute('class')).toBe(true);
+    const { element } = renderComponent();
+    expect(element).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<Section id={id} />);
-    expect(container.firstChild.id).toEqual(id);
+    const { element } = renderComponent({ id });
+    expect(element).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<Section attribute="test" />);
-    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
+    const { element } = renderComponent({ attribute: 'test' });
+    expect(element).not.toHaveAttribute('attribute');
   });
 });

--- a/app/containers/LanguageProvider/tests/index.test.js
+++ b/app/containers/LanguageProvider/tests/index.test.js
@@ -19,13 +19,14 @@ const messages = defineMessages({
 
 describe('<LanguageProvider />', () => {
   it('should render its children', () => {
-    const children = <h1>Test</h1>;
-    const { container } = render(
+    const text = 'Test';
+    const children = <h1>{text}</h1>;
+    const { queryByText } = render(
       <LanguageProvider messages={messages} locale="en">
         {children}
       </LanguageProvider>,
     );
-    expect(container.firstChild).not.toBeNull();
+    expect(queryByText(text)).toBeInTheDocument();
   });
 });
 
@@ -44,6 +45,8 @@ describe('<ConnectedLanguageProvider />', () => {
         </ConnectedLanguageProvider>
       </Provider>,
     );
-    expect(queryByText(messages.someMessage.defaultMessage)).not.toBeNull();
+    expect(
+      queryByText(messages.someMessage.defaultMessage),
+    ).toBeInTheDocument();
   });
 });

--- a/app/containers/LocaleToggle/tests/Wrapper.test.js
+++ b/app/containers/LocaleToggle/tests/Wrapper.test.js
@@ -3,26 +3,32 @@ import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<Wrapper {...props} />);
+  const wrapper = utils.container.firstChild;
+  return { ...utils, wrapper };
+};
+
 describe('<Wrapper />', () => {
-  it('should render an <div> tag', () => {
-    const { container } = render(<Wrapper />);
-    expect(container.firstChild.tagName).toEqual('DIV');
+  it('should render a <div> tag', () => {
+    const { wrapper } = renderComponent();
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper.tagName).toEqual('DIV');
   });
 
   it('should have a class attribute', () => {
-    const { container } = render(<Wrapper />);
-    expect(container.firstChild.hasAttribute('class')).toBe(true);
+    const { wrapper } = renderComponent();
+    expect(wrapper).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<Wrapper id={id} />);
-    expect(container.firstChild.hasAttribute('id')).toBe(true);
-    expect(container.firstChild.id).toEqual(id);
+    const { wrapper } = renderComponent({ id });
+    expect(wrapper).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<Wrapper attribute="test" />);
-    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
+    const { wrapper } = renderComponent({ attribute: 'test' });
+    expect(wrapper).not.toHaveAttribute('attribute');
   });
 });

--- a/app/containers/LocaleToggle/tests/index.test.js
+++ b/app/containers/LocaleToggle/tests/index.test.js
@@ -29,14 +29,14 @@ describe('<LocaleToggle />', () => {
   });
 
   it('should present the default `en` english language option', () => {
-    const { container } = render(
+    const { queryByDisplayValue } = render(
       <Provider store={store}>
         <LanguageProvider messages={translationMessages}>
           <LocaleToggle />
         </LanguageProvider>
       </Provider>,
     );
-    expect(container.querySelector('option[value="en"]')).not.toBeNull();
+    expect(queryByDisplayValue('en')).toBeInTheDocument();
   });
 
   describe('mapDispatchToProps', () => {

--- a/app/containers/NotFoundPage/tests/index.test.js
+++ b/app/containers/NotFoundPage/tests/index.test.js
@@ -16,6 +16,6 @@ describe('<NotFound />', () => {
         <NotFound />
       </IntlProvider>,
     );
-    expect(queryByText(messages.header.defaultMessage)).not.toBeNull();
+    expect(queryByText(messages.header.defaultMessage)).toBeInTheDocument();
   });
 });

--- a/app/containers/RepoListItem/tests/IssueIcon.test.js
+++ b/app/containers/RepoListItem/tests/IssueIcon.test.js
@@ -1,30 +1,28 @@
 import React from 'react';
 import { render } from 'react-testing-library';
-import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import IssueIcon from '../IssueIcon';
 
 describe('<IssueIcon />', () => {
   it('should match the snapshot', () => {
-    const renderedComponent = renderer.create(<IssueIcon />).toJSON();
-    expect(renderedComponent).toMatchSnapshot();
+    const { container } = render(<IssueIcon />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should have a className attribute', () => {
     const { container } = render(<IssueIcon />);
-    expect(container.firstChild.hasAttribute('class')).toBe(true);
+    expect(container.firstChild).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
     const { container } = render(<IssueIcon id={id} />);
-    expect(container.firstChild.hasAttribute('id')).toBe(true);
-    expect(container.firstChild.id).toEqual(id);
+    expect(container.firstChild).toHaveAttribute('id', id);
   });
 
   it('should adopt any attribute', () => {
     const { container } = render(<IssueIcon attribute="test" />);
-    expect(container.firstChild.hasAttribute('attribute')).toBe(true);
+    expect(container.firstChild).toHaveAttribute('attribute');
   });
 });

--- a/app/containers/RepoListItem/tests/IssueLink.test.js
+++ b/app/containers/RepoListItem/tests/IssueLink.test.js
@@ -1,30 +1,35 @@
 import React from 'react';
 import { render } from 'react-testing-library';
-import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import IssueLink from '../IssueLink';
 
+const renderComponent = (props = {}) => {
+  const text = 'Test';
+  const utils = render(<IssueLink {...props}>{text}</IssueLink>);
+  const element = utils.queryByText(text);
+  return { ...utils, element };
+};
+
 describe('<IssueLink />', () => {
   it('should match the snapshot', () => {
-    const renderedComponent = renderer.create(<IssueLink />).toJSON();
-    expect(renderedComponent).toMatchSnapshot();
+    const { element } = renderComponent();
+    expect(element).toMatchSnapshot();
   });
 
   it('should have a className attribute', () => {
-    const { container } = render(<IssueLink />);
-    expect(container.firstChild.hasAttribute('class')).toBe(true);
+    const { element } = renderComponent();
+    expect(element).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<IssueLink id={id} />);
-    expect(container.firstChild.hasAttribute('id')).toBe(true);
-    expect(container.firstChild.id).toEqual(id);
+    const { element } = renderComponent({ id });
+    expect(element).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<IssueLink attribute="test" />);
-    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
+    const { element } = renderComponent({ attribute: 'test' });
+    expect(element).not.toHaveAttribute('attribute');
   });
 });

--- a/app/containers/RepoListItem/tests/RepoLink.test.js
+++ b/app/containers/RepoListItem/tests/RepoLink.test.js
@@ -1,30 +1,35 @@
 import React from 'react';
 import { render } from 'react-testing-library';
-import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import RepoLink from '../RepoLink';
 
+const renderComponent = (props = {}) => {
+  const text = 'Test';
+  const utils = render(<RepoLink {...props}>{text}</RepoLink>);
+  const element = utils.queryByText(text);
+  return { ...utils, element };
+};
+
 describe('<RepoLink />', () => {
   it('should match the snapshot', () => {
-    const renderedComponent = renderer.create(<RepoLink />).toJSON();
-    expect(renderedComponent).toMatchSnapshot();
+    const { element } = renderComponent();
+    expect(element).toMatchSnapshot();
   });
 
   it('should have a className attribute', () => {
-    const { container } = render(<RepoLink />);
-    expect(container.firstChild.hasAttribute('class')).toBe(true);
+    const { element } = renderComponent();
+    expect(element).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<RepoLink id={id} />);
-    expect(container.firstChild.hasAttribute('id')).toBe(true);
-    expect(container.firstChild.id).toEqual(id);
+    const { element } = renderComponent({ id });
+    expect(element).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<RepoLink attribute="test" />);
-    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
+    const { element } = renderComponent({ attribute: 'test' });
+    expect(element).not.toHaveAttribute('attribute');
   });
 });

--- a/app/containers/RepoListItem/tests/Wrapper.test.js
+++ b/app/containers/RepoListItem/tests/Wrapper.test.js
@@ -3,26 +3,32 @@ import { render } from 'react-testing-library';
 
 import Wrapper from '../Wrapper';
 
+const renderComponent = (props = {}) => {
+  const utils = render(<Wrapper {...props} />);
+  const wrapper = utils.container.firstChild;
+  return { ...utils, wrapper };
+};
+
 describe('<Wrapper />', () => {
-  it('should render an <div> tag', () => {
-    const { container } = render(<Wrapper />);
-    expect(container.firstChild.tagName).toEqual('DIV');
+  it('should render a <div> tag', () => {
+    const { wrapper } = renderComponent();
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper.tagName).toEqual('DIV');
   });
 
-  it('should have a className attribute', () => {
-    const { container } = render(<Wrapper />);
-    expect(container.firstChild.hasAttribute('class')).toBe(true);
+  it('should have a class attribute', () => {
+    const { wrapper } = renderComponent();
+    expect(wrapper).toHaveAttribute('class');
   });
 
   it('should adopt a valid attribute', () => {
     const id = 'test';
-    const { container } = render(<Wrapper id={id} />);
-    expect(container.firstChild.hasAttribute('id')).toBe(true);
-    expect(container.firstChild.id).toEqual(id);
+    const { wrapper } = renderComponent({ id });
+    expect(wrapper).toHaveAttribute('id', id);
   });
 
   it('should not adopt an invalid attribute', () => {
-    const { container } = render(<Wrapper attribute="test" />);
-    expect(container.firstChild.hasAttribute('attribute')).toBe(false);
+    const { wrapper } = renderComponent({ attribute: 'test' });
+    expect(wrapper).not.toHaveAttribute('attribute');
   });
 });

--- a/app/containers/RepoListItem/tests/__snapshots__/IssueIcon.test.js.snap
+++ b/app/containers/RepoListItem/tests/__snapshots__/IssueIcon.test.js.snap
@@ -7,7 +7,7 @@ exports[`<IssueIcon /> should match the snapshot 1`] = `
 }
 
 <svg
-  className="c0"
+  class="c0"
   height="1em"
   width="0.875em"
 >

--- a/app/containers/RepoListItem/tests/__snapshots__/IssueLink.test.js.snap
+++ b/app/containers/RepoListItem/tests/__snapshots__/IssueLink.test.js.snap
@@ -25,6 +25,8 @@ exports[`<IssueLink /> should match the snapshot 1`] = `
 }
 
 <a
-  className="c0"
-/>
+  class="c0"
+>
+  Test
+</a>
 `;

--- a/app/containers/RepoListItem/tests/__snapshots__/RepoLink.test.js.snap
+++ b/app/containers/RepoListItem/tests/__snapshots__/RepoLink.test.js.snap
@@ -21,6 +21,8 @@ exports[`<RepoLink /> should match the snapshot 1`] = `
 }
 
 <a
-  className="c0"
-/>
+  class="c0"
+>
+  Test
+</a>
 `;

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,7 @@ module.exports = {
   setupFilesAfterEnv: [
     '<rootDir>/internals/testing/test-bundler.js',
     'react-testing-library/cleanup-after-each',
+    'jest-dom/extend-expect',
   ],
   testRegex: 'tests/.*\\.test\\.js$',
   snapshotSerializers: [],


### PR DESCRIPTION
This is a proposal to use [jest-dom](https://github.com/testing-library/jest-dom) matchers in component tests, thus making assertions more declarative and readable:
```diff
- expect(component.classList).toContain(classname)
+ expect(component).toHaveClass(classname)

- expect(component).not.toBeNull();
+ expect(component).toBeInTheDocument();

// etc.
```

For now I rewrote the basic link component test accordingly to see what you folks think about this. Also refactored the existing `renderComponent` function to return the element directly.

If approved, I can refactor the remaining components (wherever it would make sense) either all within this PR or gradually if it gets too large.


## React Boilerplate

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
- [x] Double-check your branch is based on `dev` and targets `dev` 
- [ ] Pull request has tests (we are going for 100% coverage!)
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/react-boilerplate/react-boilerplate/blob/master/LICENSE.md).
