### PR TITLE
Remove unused options.babelQuery setting

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -24,7 +24,6 @@ module.exports = options => ({
         exclude: /node_modules/,
         use: {
           loader: 'babel-loader',
-          options: options.babelQuery,
         },
       },
       {


### PR DESCRIPTION
I think this setting is just a relict from the past, it is no longer passed from either the dev or prod config.

The behaviour does not change, it defaults to using `babel.config.js` anyways.