### PR TITLE
Fix bug: Move travis xvfb start to services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ node_js:
   - 'node'
   - 'lts/*'
 
+services:
+  - xvfb
+
 script:
   - node ./internals/scripts/generate-templates-for-linting
   - npm test -- --maxWorkers=4
@@ -12,7 +15,6 @@ script:
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 
 notifications:
   email:


### PR DESCRIPTION
This PR updates the projects .travis.yml file to account for a breaking change made by the Travis team to how Xenile is started inside a build. I encountered this bug while using your excellent boilerplate project, so am passing the fix back to you!

Further details (with secondary links to documentation) can be found [here](https://benlimmer.com/2019/01/14/travis-ci-xvfb/)