### PR TITLE
Remove redundant jest-dom/extend imports

### DIFF
--- a/app/components/ListItem/tests/index.test.js
+++ b/app/components/ListItem/tests/index.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 
 import ListItem from '../index';
 

--- a/internals/generators/component/test.js.hbs
+++ b/internals/generators/component/test.js.hbs
@@ -11,7 +11,6 @@ import { render } from '@testing-library/react';
 {{#if wantMessages}}
 import { IntlProvider } from 'react-intl';
 {{/if}}
-// import '@testing-library/jest-dom/extend-expect'; // add some helpful assertions
 
 import {{ properCase name }} from '../index';
 {{#if wantMessages}}

--- a/internals/generators/container/test.js.hbs
+++ b/internals/generators/container/test.js.hbs
@@ -13,7 +13,6 @@ import { IntlProvider } from 'react-intl';
 {{/if}}
 import { Provider } from 'react-redux';
 import { browserHistory } from 'react-router-dom';
-// import '@testing-library/jest-dom/extend-expect'; // Add some helpful assertions
 
 import {{ properCase name }} from '../index';
 {{#if wantMessages}}


### PR DESCRIPTION
## React Boilerplate

These 3 lines were redundant as we already add jest-dom/extend-expect inside the Jest config.