### PR TITLE
Use semantic structure and replace div with header element

### DIFF
--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -10,10 +10,10 @@ import messages from './messages';
 
 function Header() {
   return (
-    <div>
-      <A href="https://www.reactboilerplate.com/">
-        <Img src={Banner} alt="react-boilerplate - Logo" />
-      </A>
+    <header>
+      <a href="https://www.reactboilerplate.com/">
+        <img src={Banner} alt="react-boilerplate - Logo" />
+      </a>
       <NavBar>
         <HeaderLink to="/">
           <FormattedMessage {...messages.home} />
@@ -22,7 +22,7 @@ function Header() {
           <FormattedMessage {...messages.features} />
         </HeaderLink>
       </NavBar>
-    </div>
+    </header>
   );
 }
 

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -11,9 +11,9 @@ import messages from './messages';
 function Header() {
   return (
     <header>
-      <a href="https://www.reactboilerplate.com/">
-        <img src={Banner} alt="react-boilerplate - Logo" />
-      </a>
+      <A href="https://www.reactboilerplate.com/">
+        <Img src={Banner} alt="react-boilerplate - Logo" />
+      </A>
       <NavBar>
         <HeaderLink to="/">
           <FormattedMessage {...messages.home} />


### PR DESCRIPTION
For semantic structure, `<header>` tag is missing in the code and `<footer>` tag is already in the code. And we can see that the code is broken it into header component but not using `<header>` tag.

So, replacing `<div>` with `<header>` for better semantic structure.