### PR TITLE
Add save-exact in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact = true


### PR DESCRIPTION
New dependencies will automatically be saved with an exact version (pinned)