### PR TITLE
Update injector hooks to work on first render

### DIFF
--- a/app/utils/injectReducer.js
+++ b/app/utils/injectReducer.js
@@ -38,9 +38,12 @@ export default ({ key, reducer }) => WrappedComponent => {
 const useInjectReducer = ({ key, reducer }) => {
   const store = useStore();
 
-  React.useEffect(() => {
+  const isInjected = React.useRef(false);
+
+  if (!isInjected.current) {
     getInjectors(store).injectReducer(key, reducer);
-  }, []);
+    isInjected.current = true;
+  }
 };
 
 export { useInjectReducer };

--- a/app/utils/injectSaga.js
+++ b/app/utils/injectSaga.js
@@ -49,14 +49,19 @@ export default ({ key, saga, mode }) => WrappedComponent => {
 const useInjectSaga = ({ key, saga, mode }) => {
   const store = useStore();
 
-  React.useEffect(() => {
-    const injectors = getInjectors(store);
-    injectors.injectSaga(key, { saga, mode });
+  const isInjected = React.useRef(false);
 
-    return () => {
-      injectors.ejectSaga(key);
-    };
-  }, []);
+  if (!isInjected.current) {
+    getInjectors(store).injectSaga(key, { saga, mode });
+    isInjected.current = true;
+  }
+
+  React.useEffect(
+    () => () => {
+      getInjectors(store).ejectSaga(key);
+    },
+    [],
+  );
 };
 
 export { useInjectSaga };

--- a/internals/templates/utils/injectReducer.js
+++ b/internals/templates/utils/injectReducer.js
@@ -38,9 +38,12 @@ export default ({ key, reducer }) => WrappedComponent => {
 const useInjectReducer = ({ key, reducer }) => {
   const store = useStore();
 
-  React.useEffect(() => {
+  const isInjected = React.useRef(false);
+
+  if (!isInjected.current) {
     getInjectors(store).injectReducer(key, reducer);
-  }, []);
+    isInjected.current = true;
+  }
 };
 
 export { useInjectReducer };

--- a/internals/templates/utils/injectSaga.js
+++ b/internals/templates/utils/injectSaga.js
@@ -49,14 +49,19 @@ export default ({ key, saga, mode }) => WrappedComponent => {
 const useInjectSaga = ({ key, saga, mode }) => {
   const store = useStore();
 
-  React.useEffect(() => {
-    const injectors = getInjectors(store);
-    injectors.injectSaga(key, { saga, mode });
+  const isInjected = React.useRef(false);
 
-    return () => {
-      injectors.ejectSaga(key);
-    };
-  }, []);
+  if (!isInjected.current) {
+    getInjectors(store).injectSaga(key, { saga, mode });
+    isInjected.current = true;
+  }
+
+  React.useEffect(
+    () => () => {
+      getInjectors(store).ejectSaga(key);
+    },
+    [],
+  );
 };
 
 export { useInjectSaga };


### PR DESCRIPTION
## React Boilerplate

The injector hooks currently work with useEffect. That causes an issue because we can't guarantee that the reducer or saga is always injected before a relevant action is dispatched. (See #2756 + I believe it was reported in our Spectrum once.)

In this PR, I propose an update to the API which would ensure injection happens during the first render rather than after it. It's a bit unconventional so I'd be happy to hear thoughts. At the very least, tests pass without any changes and the demo app works.

(@BenLorantfy I'll open the same PR in `redux-injectors` if we deem that this change is indeed something we want to do.)