### PR TITLE
Remove named repo author

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "npm": ">=5",
     "node": ">=8.15.1"
   },
-  "author": "Max Stoiber",
   "license": "MIT",
   "scripts": {
     "analyze:clean": "rimraf stats.json",


### PR DESCRIPTION
## React Boilerplate

The idea is to remove the `author` line from `package.json` as it credits one person over the many who have contributed to this project over the last few years. Credit for contributors is already provided via our Contributors section in README.md and @mxstbr rightfully appears first there. WDYT?