### PR TITLE
Fix analysis script to run webpack in production mode

### DIFF
--- a/internals/scripts/analyze.js
+++ b/internals/scripts/analyze.js
@@ -9,7 +9,7 @@ const progress = animateProgress('Generating stats');
 
 // Generate stats.json file with webpack
 shelljs.exec(
-  'webpack --config internals/webpack/webpack.prod.babel.js --profile --json > stats.json',
+  'cross-env NODE_ENV=production webpack --config internals/webpack/webpack.prod.babel.js --json > stats.json',
   addCheckMark.bind(null, callback), // Output a checkmark on completion
 );
 


### PR DESCRIPTION
`analysis.js` shells out to call webpack with a flag that asks it to save bundle data to a `stats.json` file in the repository's root directory. Previously, it called webpack without an environment variable telling it to run in production mode, which resulted in a `stats.json` file not reflective of the contents of the production bundle. This PR fixes this issue by setting the appropriate environment variable. Additionally, it removes the `--profile` flag in the call to webpack. See https://github.com/react-boilerplate/react-boilerplate/issues/2787 for a discussion of this change.

## React Boilerplate

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [ x ] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
- [ x ] Double-check your branch is based on `dev` and targets `dev` 
- [n.a. ] Pull request has tests (we are going for 100% coverage!)
- [ x ] Code is well-commented, linted and follows project conventions
- [n.a. ] Documentation is updated (if necessary)
- [n.a. ] Internal code generators and templates are updated (if necessary)
- [n.a. ] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/react-boilerplate/react-boilerplate/blob/master/LICENSE.md).
