### PR TITLE
Add support for nested directories with the container and component generators

### DIFF
--- a/internals/generators/component/index.js
+++ b/internals/generators/component/index.js
@@ -48,8 +48,8 @@ module.exports = {
   actions: data => {
     // Generate index.js and index.test.js
     let filePath = data.name.split('/').map(properCase)
-    const fullPath = filePath.join('/')
     const shortName = filePath.pop()
+    const fullPath = `${filePath}/${shortName}`
     filePath = filePath.join('/')
 
     const actions = [

--- a/internals/generators/component/index.js
+++ b/internals/generators/component/index.js
@@ -2,6 +2,7 @@
  * Component Generator
  */
 
+const properCase = require('change-case').pascalCase;
 const componentExists = require('../utils/componentExists');
 
 module.exports = {
@@ -13,6 +14,9 @@ module.exports = {
       message: 'What should it be called?',
       default: 'Button',
       validate: value => {
+        if( (/\/\//).test(value) )  return "A parent directory cannot have two adjacent `/`"
+        if( (/^\/|.+\/$/).test(value) ) return "A parent directory cannot start or end with a `/`"
+
         if (/.+/.test(value)) {
           return componentExists(value)
             ? 'A component or container with this name already exists'
@@ -43,16 +47,21 @@ module.exports = {
   ],
   actions: data => {
     // Generate index.js and index.test.js
+    let filePath = data.name.split('/').map(properCase)
+    const fullPath = filePath.join('/')
+    const shortName = filePath.pop()
+    filePath = filePath.join('/')
+
     const actions = [
       {
         type: 'add',
-        path: '../../app/components/{{properCase name}}/index.js',
+        path: `../../app/components/${fullPath}/index.js`,
         templateFile: './component/index.js.hbs',
         abortOnFail: true,
       },
       {
         type: 'add',
-        path: '../../app/components/{{properCase name}}/tests/index.test.js',
+        path: `../../app/components/${fullPath}/tests/index.test.js`,
         templateFile: './component/test.js.hbs',
         abortOnFail: true,
       },
@@ -62,7 +71,7 @@ module.exports = {
     if (data.wantMessages) {
       actions.push({
         type: 'add',
-        path: '../../app/components/{{properCase name}}/messages.js',
+        path: `../../app/components/${fullPath}/messages.js`,
         templateFile: './component/messages.js.hbs',
         abortOnFail: true,
       });
@@ -72,7 +81,7 @@ module.exports = {
     if (data.wantLoadable) {
       actions.push({
         type: 'add',
-        path: '../../app/components/{{properCase name}}/Loadable.js',
+        path: `../../app/components/${fullPath}/Loadable.js`,
         templateFile: './component/loadable.js.hbs',
         abortOnFail: true,
       });
@@ -80,7 +89,8 @@ module.exports = {
 
     actions.push({
       type: 'prettify',
-      path: '/components/',
+      path: `/components${filePath ? `/${filePath}/` : '/'}`,
+      name: shortName
     });
 
     return actions;

--- a/internals/generators/component/index.js
+++ b/internals/generators/component/index.js
@@ -49,8 +49,8 @@ module.exports = {
     // Generate index.js and index.test.js
     let filePath = data.name.split('/').map(properCase)
     const shortName = filePath.pop()
-    const fullPath = `${filePath}/${shortName}`
     filePath = filePath.join('/')
+    const fullPath = `${filePath}/${shortName}`
 
     const actions = [
       {

--- a/internals/generators/component/index.js
+++ b/internals/generators/component/index.js
@@ -58,12 +58,14 @@ module.exports = {
         path: `../../app/components/${fullPath}/index.js`,
         templateFile: './component/index.js.hbs',
         abortOnFail: true,
+        data: {filePath, shortName},
       },
       {
         type: 'add',
         path: `../../app/components/${fullPath}/tests/index.test.js`,
         templateFile: './component/test.js.hbs',
         abortOnFail: true,
+        data: {filePath, shortName},
       },
     ];
 
@@ -74,6 +76,7 @@ module.exports = {
         path: `../../app/components/${fullPath}/messages.js`,
         templateFile: './component/messages.js.hbs',
         abortOnFail: true,
+        data: {filePath, shortName},
       });
     }
 
@@ -84,13 +87,15 @@ module.exports = {
         path: `../../app/components/${fullPath}/Loadable.js`,
         templateFile: './component/loadable.js.hbs',
         abortOnFail: true,
+        data: {filePath, shortName},
       });
     }
 
     actions.push({
       type: 'prettify',
       path: `/components${filePath ? `/${filePath}/` : '/'}`,
-      name: shortName
+      name: shortName,
+      data: {filePath, shortName},
     });
 
     return actions;

--- a/internals/generators/component/index.js.hbs
+++ b/internals/generators/component/index.js.hbs
@@ -1,6 +1,6 @@
 /**
  *
- * {{ properCase name }}
+ * {{ filePath }}/{{ properCase shortName }}
  *
  */
 
@@ -17,7 +17,7 @@ import { FormattedMessage } from 'react-intl';
 import messages from './messages';
 {{/if}}
 
-function {{ properCase name }}() {
+function {{ properCase shortName }}() {
   return (
     <div>
     {{#if wantMessages}}
@@ -27,10 +27,10 @@ function {{ properCase name }}() {
   );
 }
 
-{{ properCase name }}.propTypes = {};
+{{ properCase shortName }}.propTypes = {};
 
 {{#if memo}}
-export default memo({{ properCase name }});
+export default memo({{ properCase shortName }});
 {{else}}
-export default {{ properCase name }};
+export default {{ properCase shortName }};
 {{/if}}

--- a/internals/generators/component/loadable.js.hbs
+++ b/internals/generators/component/loadable.js.hbs
@@ -1,6 +1,6 @@
 /**
  *
- * Asynchronously loads the component for {{ properCase name }}
+ * Asynchronously loads the component for {{ filePath }}/{{ properCase shortName }}
  *
  */
 

--- a/internals/generators/component/messages.js.hbs
+++ b/internals/generators/component/messages.js.hbs
@@ -1,7 +1,7 @@
 /*
- * {{ properCase name }} Messages
+ * {{ filePath }}/{{ properCase shortName }} Messages
  *
- * This contains all the text for the {{ properCase name }} component.
+ * This contains all the text for the {{ properCase shortName }} component.
  */
 
 import { defineMessages } from 'react-intl';

--- a/internals/generators/component/test.js.hbs
+++ b/internals/generators/component/test.js.hbs
@@ -1,6 +1,6 @@
 /**
  *
- * Tests for {{ properCase name }}
+ * Tests for {{ filePath }}/{{ properCase shortName }}
  *
  * @see https://github.com/react-boilerplate/react-boilerplate/tree/master/docs/testing
  *
@@ -12,22 +12,22 @@ import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 {{/if}}
 
-import {{ properCase name }} from '../index';
+import {{ properCase shortName }} from '../index';
 {{#if wantMessages}}
 import { DEFAULT_LOCALE } from '../../../locales';
 {{/if}}
 
-describe('<{{ properCase name }} />', () => {
+describe('<{{ properCase shortName }} />', () => {
   it('Expect to not log errors in console', () => {
     const spy = jest.spyOn(global.console, 'error');
 {{#if wantMessages}}
     render(
       <IntlProvider locale={DEFAULT_LOCALE}>
-        <{{ properCase name }} />
+        <{{ properCase shortName }} />
       </IntlProvider>,
     );
 {{else}}
-    render(<{{ properCase name }} />);
+    render(<{{ properCase shortName }} />);
 {{/if}}
     expect(spy).not.toHaveBeenCalled();
   });
@@ -47,13 +47,13 @@ describe('<{{ properCase name }} />', () => {
       container: { firstChild },
     } = render(
       <IntlProvider locale={DEFAULT_LOCALE}>
-        <{{ properCase name }} />
+        <{{ properCase shortName }} />
       </IntlProvider>,
     );
 {{else}}
     const {
       container: { firstChild },
-    } = render(<{{ properCase name }} />);
+    } = render(<{{ properCase shortName }} />);
 {{/if}}
     expect(firstChild).toMatchSnapshot();
   });

--- a/internals/generators/container/index.js
+++ b/internals/generators/container/index.js
@@ -65,13 +65,13 @@ module.exports = {
     const actions = [
       {
         type: 'add',
-        path: `../../app/containers/{{properCase name}}/index.js`,
+        path: '../../app/containers/{{properCase name}}/index.js',
         templateFile: './container/index.js.hbs',
         abortOnFail: true,
       },
       {
         type: 'add',
-        path: `../../app/containers/{{properCase name}}/tests/index.test.js`,
+        path: '../../app/containers/{{properCase name}}/tests/index.test.js',
         templateFile: './container/test.js.hbs',
         abortOnFail: true,
       },

--- a/internals/generators/container/index.js
+++ b/internals/generators/container/index.js
@@ -1,8 +1,7 @@
 /**
  * Container Generator
  */
- 
-const properCase = require('change-case').pascalCase;
+
 const componentExists = require('../utils/componentExists');
 
 module.exports = {
@@ -14,9 +13,6 @@ module.exports = {
       message: 'What should it be called?',
       default: 'Form',
       validate: value => {
-        if( (/\/\//).test(value) )  return "A parent directory cannot have two adjacent `/`"
-        if( (/^\/|.+\/$/).test(value) ) return "A parent directory cannot start or end with a `/`"
-
         if (/.+/.test(value)) {
           return componentExists(value)
             ? 'A component or container with this name already exists'
@@ -66,21 +62,16 @@ module.exports = {
   ],
   actions: data => {
     // Generate index.js and index.test.js
-    let filePath = data.name.split('/').map(properCase)
-    const shortName = filePath.pop()
-    const fullPath = `${filePath}/${shortName}`
-    filePath = filePath.join('/')
-
     const actions = [
       {
         type: 'add',
-        path: `../../app/containers/${fullPath}/index.js`,
+        path: `../../app/containers/{{properCase name}}/index.js`,
         templateFile: './container/index.js.hbs',
         abortOnFail: true,
       },
       {
         type: 'add',
-        path: `../../app/containers/${fullPath}/tests/index.test.js`,
+        path: `../../app/containers/{{properCase name}}/tests/index.test.js`,
         templateFile: './container/test.js.hbs',
         abortOnFail: true,
       },
@@ -90,7 +81,7 @@ module.exports = {
     if (data.wantMessages) {
       actions.push({
         type: 'add',
-        path: `../../app/containers/${fullPath}/messages.js`,
+        path: '../../app/containers/{{properCase name}}/messages.js',
         templateFile: './container/messages.js.hbs',
         abortOnFail: true,
       });
@@ -102,13 +93,13 @@ module.exports = {
       // Actions
       actions.push({
         type: 'add',
-        path: `../../app/containers/${fullPath}/actions.js`,
+        path: '../../app/containers/{{properCase name}}/actions.js',
         templateFile: './container/actions.js.hbs',
         abortOnFail: true,
       });
       actions.push({
         type: 'add',
-        path: `../../app/containers/${fullPath}/tests/actions.test.js`,
+        path: '../../app/containers/{{properCase name}}/tests/actions.test.js',
         templateFile: './container/actions.test.js.hbs',
         abortOnFail: true,
       });
@@ -116,7 +107,7 @@ module.exports = {
       // Constants
       actions.push({
         type: 'add',
-        path: `../../app/containers/${fullPath}/constants.js`,
+        path: '../../app/containers/{{properCase name}}/constants.js',
         templateFile: './container/constants.js.hbs',
         abortOnFail: true,
       });
@@ -124,14 +115,14 @@ module.exports = {
       // Selectors
       actions.push({
         type: 'add',
-        path: `../../app/containers/${fullPath}/selectors.js`,
+        path: '../../app/containers/{{properCase name}}/selectors.js',
         templateFile: './container/selectors.js.hbs',
         abortOnFail: true,
       });
       actions.push({
         type: 'add',
         path:
-          `../../app/containers/${fullPath}/tests/selectors.test.js`,
+          '../../app/containers/{{properCase name}}/tests/selectors.test.js',
         templateFile: './container/selectors.test.js.hbs',
         abortOnFail: true,
       });
@@ -139,13 +130,13 @@ module.exports = {
       // Reducer
       actions.push({
         type: 'add',
-        path: `../../app/containers/${fullPath}/reducer.js`,
+        path: '../../app/containers/{{properCase name}}/reducer.js',
         templateFile: './container/reducer.js.hbs',
         abortOnFail: true,
       });
       actions.push({
         type: 'add',
-        path: `../../app/containers/${fullPath}/tests/reducer.test.js`,
+        path: '../../app/containers/{{properCase name}}/tests/reducer.test.js',
         templateFile: './container/reducer.test.js.hbs',
         abortOnFail: true,
       });
@@ -155,13 +146,13 @@ module.exports = {
     if (data.wantSaga) {
       actions.push({
         type: 'add',
-        path: `../../app/containers/${fullPath}/saga.js`,
+        path: '../../app/containers/{{properCase name}}/saga.js',
         templateFile: './container/saga.js.hbs',
         abortOnFail: true,
       });
       actions.push({
         type: 'add',
-        path: `../../app/containers/${fullPath}/tests/saga.test.js`,
+        path: '../../app/containers/{{properCase name}}/tests/saga.test.js',
         templateFile: './container/saga.test.js.hbs',
         abortOnFail: true,
       });
@@ -170,7 +161,7 @@ module.exports = {
     if (data.wantLoadable) {
       actions.push({
         type: 'add',
-        path: `../../app/containers/${fullPath}/Loadable.js`,
+        path: '../../app/containers/{{properCase name}}/Loadable.js',
         templateFile: './component/loadable.js.hbs',
         abortOnFail: true,
       });
@@ -178,10 +169,8 @@ module.exports = {
 
     actions.push({
       type: 'prettify',
-      path: `/containers${filePath ? `/${filePath}/` : '/'}`,
-      name: shortName
+      path: '/containers/',
     });
-
 
     return actions;
   },

--- a/internals/generators/container/index.js
+++ b/internals/generators/container/index.js
@@ -1,7 +1,8 @@
 /**
  * Container Generator
  */
-
+ 
+const properCase = require('change-case').pascalCase;
 const componentExists = require('../utils/componentExists');
 
 module.exports = {
@@ -13,6 +14,9 @@ module.exports = {
       message: 'What should it be called?',
       default: 'Form',
       validate: value => {
+        if( (/\/\//).test(value) )  return "A parent directory cannot have two adjacent `/`"
+        if( (/^\/|.+\/$/).test(value) ) return "A parent directory cannot start or end with a `/`"
+
         if (/.+/.test(value)) {
           return componentExists(value)
             ? 'A component or container with this name already exists'
@@ -62,16 +66,21 @@ module.exports = {
   ],
   actions: data => {
     // Generate index.js and index.test.js
+    let filePath = data.name.split('/').map(properCase)
+    const fullPath = filePath.join('/')
+    const shortName = filePath.pop()
+    filePath = filePath.join('/')
+
     const actions = [
       {
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/index.js',
+        path: `../../app/containers/${fullPath}/index.js`,
         templateFile: './container/index.js.hbs',
         abortOnFail: true,
       },
       {
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/tests/index.test.js',
+        path: `../../app/containers/${fullPath}/tests/index.test.js`,
         templateFile: './container/test.js.hbs',
         abortOnFail: true,
       },
@@ -81,7 +90,7 @@ module.exports = {
     if (data.wantMessages) {
       actions.push({
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/messages.js',
+        path: `../../app/containers/${fullPath}/messages.js`,
         templateFile: './container/messages.js.hbs',
         abortOnFail: true,
       });
@@ -93,13 +102,13 @@ module.exports = {
       // Actions
       actions.push({
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/actions.js',
+        path: `../../app/containers/${fullPath}/actions.js`,
         templateFile: './container/actions.js.hbs',
         abortOnFail: true,
       });
       actions.push({
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/tests/actions.test.js',
+        path: `../../app/containers/${fullPath}/tests/actions.test.js`,
         templateFile: './container/actions.test.js.hbs',
         abortOnFail: true,
       });
@@ -107,7 +116,7 @@ module.exports = {
       // Constants
       actions.push({
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/constants.js',
+        path: `../../app/containers/${fullPath}/constants.js`,
         templateFile: './container/constants.js.hbs',
         abortOnFail: true,
       });
@@ -115,14 +124,14 @@ module.exports = {
       // Selectors
       actions.push({
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/selectors.js',
+        path: `../../app/containers/${fullPath}/selectors.js`,
         templateFile: './container/selectors.js.hbs',
         abortOnFail: true,
       });
       actions.push({
         type: 'add',
         path:
-          '../../app/containers/{{properCase name}}/tests/selectors.test.js',
+          `../../app/containers/${fullPath}/tests/selectors.test.js`,
         templateFile: './container/selectors.test.js.hbs',
         abortOnFail: true,
       });
@@ -130,13 +139,13 @@ module.exports = {
       // Reducer
       actions.push({
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/reducer.js',
+        path: `../../app/containers/${fullPath}/reducer.js`,
         templateFile: './container/reducer.js.hbs',
         abortOnFail: true,
       });
       actions.push({
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/tests/reducer.test.js',
+        path: `../../app/containers/${fullPath}/tests/reducer.test.js`,
         templateFile: './container/reducer.test.js.hbs',
         abortOnFail: true,
       });
@@ -146,13 +155,13 @@ module.exports = {
     if (data.wantSaga) {
       actions.push({
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/saga.js',
+        path: `../../app/containers/${fullPath}/saga.js`,
         templateFile: './container/saga.js.hbs',
         abortOnFail: true,
       });
       actions.push({
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/tests/saga.test.js',
+        path: `../../app/containers/${fullPath}/tests/saga.test.js`,
         templateFile: './container/saga.test.js.hbs',
         abortOnFail: true,
       });
@@ -161,7 +170,7 @@ module.exports = {
     if (data.wantLoadable) {
       actions.push({
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/Loadable.js',
+        path: `../../app/containers/${fullPath}/Loadable.js`,
         templateFile: './component/loadable.js.hbs',
         abortOnFail: true,
       });
@@ -169,8 +178,10 @@ module.exports = {
 
     actions.push({
       type: 'prettify',
-      path: '/containers/',
+      path: `/containers${filePath ? `/${filePath}/` : '/'}`,
+      name: shortName
     });
+
 
     return actions;
   },

--- a/internals/generators/container/index.js
+++ b/internals/generators/container/index.js
@@ -67,8 +67,8 @@ module.exports = {
   actions: data => {
     // Generate index.js and index.test.js
     let filePath = data.name.split('/').map(properCase)
-    const fullPath = filePath.join('/')
     const shortName = filePath.pop()
+    const fullPath = `${filePath}/${shortName}`
     filePath = filePath.join('/')
 
     const actions = [

--- a/internals/generators/index.js
+++ b/internals/generators/index.js
@@ -27,7 +27,7 @@ module.exports = plop => {
       __dirname,
       '/../../app/',
       config.path,
-      plop.getHelper('properCase')(answers.name),
+      plop.getHelper('properCase')(config.name || answers.name),
       '**',
       '**.js',
     )}`;

--- a/internals/generators/utils/componentExists.js
+++ b/internals/generators/utils/componentExists.js
@@ -4,18 +4,23 @@
  * Check whether the given component exist in either the components or containers directory
  */
 
-const fs = require('fs');
 const path = require('path');
-const pageComponents = fs.readdirSync(
-  path.join(__dirname, '../../../app/components'),
-);
-const pageContainers = fs.readdirSync(
-  path.join(__dirname, '../../../app/containers'),
-);
-const components = pageComponents.concat(pageContainers);
+
+const walkNestedComponents = require('./walkNestedComponents')
+
+const pageComponents = walkNestedComponents(path.join(__dirname,'../../../app/components'))
+const pageContainers = walkNestedComponents(path.join(__dirname,'../../../app/containers'))
+
+const components = pageComponents.concat(pageContainers)
 
 function componentExists(comp) {
-  return components.indexOf(comp) >= 0;
+  const containerPath = path.join(__dirname, `../../../app/containers/${comp}`)
+  const componentPath = path.join(__dirname, `../../../app/components/${comp}`)
+	
+  	return (
+  		components.indexOf(containerPath) >= 0 ||
+  		components.indexOf(componentPath) >= 0
+  	);
 }
 
 module.exports = componentExists;

--- a/internals/generators/utils/walkNestedComponents.js
+++ b/internals/generators/utils/walkNestedComponents.js
@@ -1,0 +1,31 @@
+/**
+ * walkNestedComponents
+ *
+ * List all components listed within a directory
+ */
+
+const fs = require('fs');
+
+function walkNestedComponents(dir) {
+  let results = [];
+  const list = fs.readdirSync(dir);
+  list.forEach((file) => {
+    	// Only include the directory as a component if `index.js` is defined
+    	if(file === 'index.js')
+    	{
+    		results.push(dir)
+    	}
+    	else
+    	{
+	        const filePath = `${dir}/${file}`;
+	        const stat = fs.statSync(filePath);
+	        if (stat && stat.isDirectory()) { 
+	            /* Recurse into a subdirectory */
+	            results = results.concat(walkNestedComponents(filePath));
+	        }
+	    }
+  });
+  return results;
+}
+
+module.exports = walkNestedComponents

--- a/package-lock.json
+++ b/package-lock.json
@@ -4514,6 +4514,35 @@
       "integrity": "sha512-h+Eqyn/YA6o6ZTqpS86PyRmNWOs1r54EBDcd2NTwwfsXQ8re1B38SnB+p2RKF8OUsyEIjeDU8XGec1RGO/wYCg==",
       "dev": true
     },
+    "capital-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.3.tgz",
+      "integrity": "sha512-OlUSJpUr7SY0uZFOxcwnDOU7/MpHlKTZx2mqnDYQFrDudXLFm0JJ9wr/l4csB+rh2Ug0OPuoSO53PqiZBqno9A==",
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0",
+        "upper-case-first": "^2.0.1"
+      },
+      "dependencies": {
+        "lower-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "no-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "requires": {
+            "lower-case": "^2.0.1",
+            "tslib": "^1.10.0"
+          }
+        }
+      }
+    },
     "capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -4567,29 +4596,59 @@
       }
     },
     "change-case": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.1.0.tgz",
-      "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.1.tgz",
+      "integrity": "sha512-qRlUWn/hXnX1R1LBDF/RelJLiqNjKjUqlmuBVSEIyye8kq49CXqkZWKmi8XeUAdDXWFOcGLUMZ+aHn3Q5lzUXw==",
       "requires": {
-        "camel-case": "^3.0.0",
-        "constant-case": "^2.0.0",
-        "dot-case": "^2.1.0",
-        "header-case": "^1.0.0",
-        "is-lower-case": "^1.1.0",
-        "is-upper-case": "^1.1.0",
-        "lower-case": "^1.1.1",
-        "lower-case-first": "^1.0.0",
-        "no-case": "^2.3.2",
-        "param-case": "^2.1.0",
-        "pascal-case": "^2.0.0",
-        "path-case": "^2.1.0",
-        "sentence-case": "^2.1.0",
-        "snake-case": "^2.1.0",
-        "swap-case": "^1.1.0",
-        "title-case": "^2.1.0",
-        "upper-case": "^1.1.1",
-        "upper-case-first": "^1.1.0"
+        "camel-case": "^4.1.1",
+        "capital-case": "^1.0.3",
+        "constant-case": "^3.0.3",
+        "dot-case": "^3.0.3",
+        "header-case": "^2.0.3",
+        "no-case": "^3.0.3",
+        "param-case": "^3.0.3",
+        "pascal-case": "^3.1.1",
+        "path-case": "^3.0.3",
+        "sentence-case": "^3.0.3",
+        "snake-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "camel-case": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+          "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+          "requires": {
+            "pascal-case": "^3.1.1",
+            "tslib": "^1.10.0"
+          }
+        },
+        "lower-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "no-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "requires": {
+            "lower-case": "^2.0.1",
+            "tslib": "^1.10.0"
+          }
+        },
+        "param-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
+          "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
+          "requires": {
+            "dot-case": "^3.0.3",
+            "tslib": "^1.10.0"
+          }
+        }
       }
     },
     "character-entities": {
@@ -5198,13 +5257,40 @@
       "optional": true
     },
     "constant-case": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
-      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
-      "dev": true,
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.3.tgz",
+      "integrity": "sha512-FXtsSnnrFYpzDmvwDGQW+l8XK3GV1coLyBN0eBz16ZUzGaZcT2ANVCJmLeuw2GQgxKHQIe9e0w2dzkSfaRlUmA==",
       "requires": {
-        "snake-case": "^2.1.0",
-        "upper-case": "^1.1.1"
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0",
+        "upper-case": "^2.0.1"
+      },
+      "dependencies": {
+        "lower-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "no-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "requires": {
+            "lower-case": "^2.0.1",
+            "tslib": "^1.10.0"
+          }
+        },
+        "upper-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.1.tgz",
+          "integrity": "sha512-laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        }
       }
     },
     "constants-browserify": {
@@ -6295,12 +6381,31 @@
       }
     },
     "dot-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
-      "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
-      "dev": true,
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
+      "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "lower-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "no-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "requires": {
+            "lower-case": "^2.0.1",
+            "tslib": "^1.10.0"
+          }
+        }
       }
     },
     "dot-prop": {
@@ -9078,13 +9183,12 @@
       "dev": true
     },
     "header-case": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
-      "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
-      "dev": true,
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.3.tgz",
+      "integrity": "sha512-LChe/V32mnUQnTwTxd3aAlNMk8ia9tjCDb/LjYtoMrdAPApxLB+azejUk5ERZIZdIqvinwv6BAUuFXH/tQPdZA==",
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.3"
+        "capital-case": "^1.0.3",
+        "tslib": "^1.10.0"
       }
     },
     "history": {
@@ -13855,6 +13959,42 @@
             "fill-range": "^7.0.1"
           }
         },
+        "change-case": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.1.0.tgz",
+          "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
+          "dev": true,
+          "requires": {
+            "camel-case": "^3.0.0",
+            "constant-case": "^2.0.0",
+            "dot-case": "^2.1.0",
+            "header-case": "^1.0.0",
+            "is-lower-case": "^1.1.0",
+            "is-upper-case": "^1.1.0",
+            "lower-case": "^1.1.1",
+            "lower-case-first": "^1.0.0",
+            "no-case": "^2.3.2",
+            "param-case": "^2.1.0",
+            "pascal-case": "^2.0.0",
+            "path-case": "^2.1.0",
+            "sentence-case": "^2.1.0",
+            "snake-case": "^2.1.0",
+            "swap-case": "^1.1.0",
+            "title-case": "^2.1.0",
+            "upper-case": "^1.1.1",
+            "upper-case-first": "^1.1.0"
+          }
+        },
+        "constant-case": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+          "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+          "dev": true,
+          "requires": {
+            "snake-case": "^2.1.0",
+            "upper-case": "^1.1.1"
+          }
+        },
         "core-js": {
           "version": "3.4.2",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.2.tgz",
@@ -13868,6 +14008,15 @@
           "dev": true,
           "requires": {
             "path-type": "^4.0.0"
+          }
+        },
+        "dot-case": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
+          "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0"
           }
         },
         "fast-glob": {
@@ -13917,6 +14066,16 @@
             "slash": "^3.0.0"
           }
         },
+        "header-case": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
+          "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case": "^1.1.3"
+          }
+        },
         "ignore": {
           "version": "5.1.4",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
@@ -13939,17 +14098,55 @@
             "picomatch": "^2.0.5"
           }
         },
+        "pascal-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+          "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+          "dev": true,
+          "requires": {
+            "camel-case": "^3.0.0",
+            "upper-case-first": "^1.1.0"
+          }
+        },
+        "path-case": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
+          "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        },
         "path-type": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         },
+        "sentence-case": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
+          "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case-first": "^1.1.2"
+          }
+        },
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
+        },
+        "snake-case": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+          "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
         },
         "to-regex-range": {
           "version": "5.0.1",
@@ -13958,6 +14155,15 @@
           "dev": true,
           "requires": {
             "is-number": "^7.0.0"
+          }
+        },
+        "upper-case-first": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+          "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+          "dev": true,
+          "requires": {
+            "upper-case": "^1.1.1"
           }
         }
       }
@@ -14831,13 +15037,31 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "pascal-case": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
-      "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
-      "dev": true,
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+      "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
       "requires": {
-        "camel-case": "^3.0.0",
-        "upper-case-first": "^1.1.0"
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "lower-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "no-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "requires": {
+            "lower-case": "^2.0.1",
+            "tslib": "^1.10.0"
+          }
+        }
       }
     },
     "pascalcase": {
@@ -14853,12 +15077,12 @@
       "dev": true
     },
     "path-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
-      "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
-      "dev": true,
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.3.tgz",
+      "integrity": "sha512-UMFU6UETFpCNWbIWNczshPrnK/7JAXBP2NYw80ojElbQ2+JYxdqWDBkvvqM93u4u6oLmuJ/tPOf2tM8KtXv4eg==",
       "requires": {
-        "no-case": "^2.2.0"
+        "dot-case": "^3.0.3",
+        "tslib": "^1.10.0"
       }
     },
     "path-dirname": {
@@ -17191,13 +17415,32 @@
       }
     },
     "sentence-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
-      "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
-      "dev": true,
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.3.tgz",
+      "integrity": "sha512-ZPr4dgTcNkEfcGOMFQyDdJrTU9uQO1nb1cjf+nuzb6FxgMDgKddZOM29qEsB7jvsZSMruLRcL2KfM4ypKpa0LA==",
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case-first": "^1.1.2"
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0",
+        "upper-case-first": "^2.0.1"
+      },
+      "dependencies": {
+        "lower-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "no-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "requires": {
+            "lower-case": "^2.0.1",
+            "tslib": "^1.10.0"
+          }
+        }
       }
     },
     "serialize-javascript": {
@@ -17369,12 +17612,12 @@
       }
     },
     "snake-case": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
-      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
-      "dev": true,
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.3.tgz",
+      "integrity": "sha512-WM1sIXEO+rsAHBKjGf/6R1HBBcgbncKS08d2Aqec/mrDSpU80SiOU41hO7ny6DToHSyrlwTYzQBIK1FPSx4Y3Q==",
       "requires": {
-        "no-case": "^2.2.0"
+        "dot-case": "^3.0.3",
+        "tslib": "^1.10.0"
       }
     },
     "snapdragon": {
@@ -19344,8 +19587,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -19700,12 +19942,11 @@
       "dev": true
     },
     "upper-case-first": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
-      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.1.tgz",
+      "integrity": "sha512-105J8XqQ+9RxW3l9gHZtgve5oaiR9TIwvmZAMAIZWRHe00T21cdvewKORTlOJf/zXW6VukuTshM+HXZNWz7N5w==",
       "requires": {
-        "upper-case": "^1.1.1"
+        "tslib": "^1.10.0"
       }
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@hot-loader/react-dom": "16.11.0",
     "chalk": "3.0.0",
+    "change-case": "4.1.1",
     "compression": "1.7.4",
     "connected-react-router": "6.6.0",
     "cross-env": "6.0.3",
@@ -85,8 +86,8 @@
     "react-redux": "7.1.3",
     "react-router-dom": "5.1.2",
     "redux": "4.0.4",
-    "redux-saga": "1.1.3",
     "redux-injectors": "1.2.0",
+    "redux-saga": "1.1.3",
     "reselect": "4.0.0",
     "sanitize.css": "11.0.0",
     "styled-components": "4.4.1"


### PR DESCRIPTION
## React Boilerplate

- [✔️] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
- [✔️] Double-check your branch is based on `dev` and targets `dev` 
- [❌] Pull request has tests (we are going for 100% coverage!)
- [✔️] Code is well-commented, linted and follows project conventions
- [❌] Documentation is updated (if necessary)
- [✔️] Internal code generators and templates are updated (if necessary)
- [✔️] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/react-boilerplate/react-boilerplate/blob/master/LICENSE.md).

---

I don't know if this feature addition follows best practices or if it's even wanted, but I've been using this modified version of the component/container generators for about 3 years now and it's done wonders for keeping my project components more organized.

It effectively allows for components and containers to be nested in subdirectories, while still allowing each subcomponent to have all the benefits react-boilerplate's generators create (like unit tests and messages). By simply adding `/`s to component names will create subdirectories all the way up until the last value, which will then be used as the component name (which behaves exactly as it does now). I made this entirely as an "opt-in" style of usage, so if people want to continue using it exactly how they do now they should experience no difference.

Here are some examples of how this works (it should identical for containers as well, just with additional container-specific files):

`npm run generate component Events` will generate an `Events` component exactly as it does now.

`npm run generate component Events/Index` will generate an `Index` component inside of the `Events` directory otherwise leaving all the existing files in the `components/Events` untouched.

Another cool part is let's say you don't want a root component, but want to have a handful of related components grouped together in the same directory. You can skip over the initial directory generator and go straight to the subcomponent. e.g. `npm run generate component Buttons/Confirmation`. A `Confirmation` component will be made inside of a `Buttons` directory, but no component will be made directly in the `Buttons` directory.
```
npm run generate component Buttons/Confirmation;
npm run generate component Buttons/Cancelation;
```
would generate a directory structure like this:
```
components/
    Buttons/
        Confirmation/
            index.js
            ...
         Cancelation/
            index.js
            ...
```

Let's say you later realized you did actually want to have a `Button` component as a base for the subcomponent. All you would need to do is run `npm run generate component Button` and a `Button` component would be made like normal without disturbing the `Confirmation` and `Cancelation` components.

I typically use this for CRUD type development, but I could see it used in a plethora of ways for organizing related components. My "real world" example being structured something like this.

```
Events/
   Index/
      index.js
   Show/
      index.js
   Edit/
      index.js
```
 
So rather than cluttering the root directory with components like `EventIndex`, `EventShow`, `EventEdit` all the components are nicely grouped together in the `Events` directory.

I hope you see a value in this type of setup, and if you do I will go on to write appropriate tests and update whatever documentation is necessary!