### PR TITLE
Migrate to styled-components v5

### DIFF
--- a/app/components/Footer/tests/__snapshots__/index.test.js.snap
+++ b/app/components/Footer/tests/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Footer /> should render and match the snapshot 1`] = `
 <footer
-  className="Wrapper-wcfdfo-0 dPvBog"
+  className="Wrapper-wcfdfo-0 gkRjxJ"
 >
   <section>
     <span>
@@ -11,10 +11,10 @@ exports[`<Footer /> should render and match the snapshot 1`] = `
   </section>
   <section>
     <div
-      className="Wrapper-xnjoq9-0 dNmQIR"
+      className="Wrapper-xnjoq9-0 jdNcyG"
     >
       <select
-        className="Select-sc-1sm01tk-0 wIjFa"
+        className="Select-sc-1sm01tk-0 UGvsg"
         onChange={[Function]}
         value="en"
       >
@@ -36,7 +36,7 @@ exports[`<Footer /> should render and match the snapshot 1`] = `
       
       Made with love by 
       <a
-        className="A-br8h0y-0 dwVNvo"
+        className="A-br8h0y-0 keMyW"
         href="https://twitter.com/mxstbr"
       >
         Max Stoiber

--- a/app/components/Header/tests/__snapshots__/A.test.js.snap
+++ b/app/components/Header/tests/__snapshots__/A.test.js.snap
@@ -11,7 +11,7 @@ exports[`<A /> should match the snapshot 1`] = `
 }
 
 <a
-  class="c0"
+  class="A-br8h0y-0 c0"
 >
   Link
 </a>

--- a/app/components/Header/tests/__snapshots__/index.test.js.snap
+++ b/app/components/Header/tests/__snapshots__/index.test.js.snap
@@ -3,20 +3,20 @@
 exports[`<Header /> should render a div 1`] = `
 <div>
   <a
-    class="A-br8h0y-0 A-p44m4v-0 cYguYL"
+    class="A-br8h0y-0 A-p44m4v-0 fpPmEB"
     href="https://www.reactboilerplate.com/"
   >
     <img
       alt="react-boilerplate - Logo"
-      class="Img-sc-9pa8on-0 eepIiv"
+      class="Img-sc-9pa8on-0 jrqChG"
       src="IMAGE_MOCK"
     />
   </a>
   <div
-    class="NavBar___default-sc-3b48xb-0 VAzAd"
+    class="NavBar___default-sc-3b48xb-0 kgyoSn"
   >
     <a
-      class="HeaderLink___default-sc-1mtyaiv-0 ljfKqy"
+      class="HeaderLink___default-sc-1mtyaiv-0 eKMaLw"
       href="/"
     >
       <span>
@@ -24,7 +24,7 @@ exports[`<Header /> should render a div 1`] = `
       </span>
     </a>
     <a
-      class="HeaderLink___default-sc-1mtyaiv-0 ljfKqy"
+      class="HeaderLink___default-sc-1mtyaiv-0 eKMaLw"
       href="/features"
     >
       <span>

--- a/app/components/LoadingIndicator/tests/__snapshots__/index.test.js.snap
+++ b/app/components/LoadingIndicator/tests/__snapshots__/index.test.js.snap
@@ -24,8 +24,8 @@ exports[`<LoadingIndicator /> should match the snapshot 1`] = `
   height: 15%;
   background-color: #999;
   border-radius: 100%;
-  -webkit-animation: evVlQQ 1.2s infinite ease-in-out both;
-  animation: evVlQQ 1.2s infinite ease-in-out both;
+  -webkit-animation: klxJsx 1.2s infinite ease-in-out both;
+  animation: klxJsx 1.2s infinite ease-in-out both;
 }
 
 .c2 {
@@ -49,8 +49,8 @@ exports[`<LoadingIndicator /> should match the snapshot 1`] = `
   height: 15%;
   background-color: #999;
   border-radius: 100%;
-  -webkit-animation: evVlQQ 1.2s infinite ease-in-out both;
-  animation: evVlQQ 1.2s infinite ease-in-out both;
+  -webkit-animation: klxJsx 1.2s infinite ease-in-out both;
+  animation: klxJsx 1.2s infinite ease-in-out both;
   -webkit-animation-delay: -1.1s;
   -webkit-animation-delay: -1.1s;
   animation-delay: -1.1s;
@@ -77,8 +77,8 @@ exports[`<LoadingIndicator /> should match the snapshot 1`] = `
   height: 15%;
   background-color: #999;
   border-radius: 100%;
-  -webkit-animation: evVlQQ 1.2s infinite ease-in-out both;
-  animation: evVlQQ 1.2s infinite ease-in-out both;
+  -webkit-animation: klxJsx 1.2s infinite ease-in-out both;
+  animation: klxJsx 1.2s infinite ease-in-out both;
   -webkit-animation-delay: -1s;
   -webkit-animation-delay: -1s;
   animation-delay: -1s;
@@ -105,8 +105,8 @@ exports[`<LoadingIndicator /> should match the snapshot 1`] = `
   height: 15%;
   background-color: #999;
   border-radius: 100%;
-  -webkit-animation: evVlQQ 1.2s infinite ease-in-out both;
-  animation: evVlQQ 1.2s infinite ease-in-out both;
+  -webkit-animation: klxJsx 1.2s infinite ease-in-out both;
+  animation: klxJsx 1.2s infinite ease-in-out both;
   -webkit-animation-delay: -0.9s;
   -webkit-animation-delay: -0.9s;
   animation-delay: -0.9s;
@@ -133,8 +133,8 @@ exports[`<LoadingIndicator /> should match the snapshot 1`] = `
   height: 15%;
   background-color: #999;
   border-radius: 100%;
-  -webkit-animation: evVlQQ 1.2s infinite ease-in-out both;
-  animation: evVlQQ 1.2s infinite ease-in-out both;
+  -webkit-animation: klxJsx 1.2s infinite ease-in-out both;
+  animation: klxJsx 1.2s infinite ease-in-out both;
   -webkit-animation-delay: -0.8s;
   -webkit-animation-delay: -0.8s;
   animation-delay: -0.8s;
@@ -161,8 +161,8 @@ exports[`<LoadingIndicator /> should match the snapshot 1`] = `
   height: 15%;
   background-color: #999;
   border-radius: 100%;
-  -webkit-animation: evVlQQ 1.2s infinite ease-in-out both;
-  animation: evVlQQ 1.2s infinite ease-in-out both;
+  -webkit-animation: klxJsx 1.2s infinite ease-in-out both;
+  animation: klxJsx 1.2s infinite ease-in-out both;
   -webkit-animation-delay: -0.7s;
   -webkit-animation-delay: -0.7s;
   animation-delay: -0.7s;
@@ -189,8 +189,8 @@ exports[`<LoadingIndicator /> should match the snapshot 1`] = `
   height: 15%;
   background-color: #999;
   border-radius: 100%;
-  -webkit-animation: evVlQQ 1.2s infinite ease-in-out both;
-  animation: evVlQQ 1.2s infinite ease-in-out both;
+  -webkit-animation: klxJsx 1.2s infinite ease-in-out both;
+  animation: klxJsx 1.2s infinite ease-in-out both;
   -webkit-animation-delay: -0.6s;
   -webkit-animation-delay: -0.6s;
   animation-delay: -0.6s;
@@ -217,8 +217,8 @@ exports[`<LoadingIndicator /> should match the snapshot 1`] = `
   height: 15%;
   background-color: #999;
   border-radius: 100%;
-  -webkit-animation: evVlQQ 1.2s infinite ease-in-out both;
-  animation: evVlQQ 1.2s infinite ease-in-out both;
+  -webkit-animation: klxJsx 1.2s infinite ease-in-out both;
+  animation: klxJsx 1.2s infinite ease-in-out both;
   -webkit-animation-delay: -0.5s;
   -webkit-animation-delay: -0.5s;
   animation-delay: -0.5s;
@@ -245,8 +245,8 @@ exports[`<LoadingIndicator /> should match the snapshot 1`] = `
   height: 15%;
   background-color: #999;
   border-radius: 100%;
-  -webkit-animation: evVlQQ 1.2s infinite ease-in-out both;
-  animation: evVlQQ 1.2s infinite ease-in-out both;
+  -webkit-animation: klxJsx 1.2s infinite ease-in-out both;
+  animation: klxJsx 1.2s infinite ease-in-out both;
   -webkit-animation-delay: -0.4s;
   -webkit-animation-delay: -0.4s;
   animation-delay: -0.4s;
@@ -273,8 +273,8 @@ exports[`<LoadingIndicator /> should match the snapshot 1`] = `
   height: 15%;
   background-color: #999;
   border-radius: 100%;
-  -webkit-animation: evVlQQ 1.2s infinite ease-in-out both;
-  animation: evVlQQ 1.2s infinite ease-in-out both;
+  -webkit-animation: klxJsx 1.2s infinite ease-in-out both;
+  animation: klxJsx 1.2s infinite ease-in-out both;
   -webkit-animation-delay: -0.3s;
   -webkit-animation-delay: -0.3s;
   animation-delay: -0.3s;
@@ -301,8 +301,8 @@ exports[`<LoadingIndicator /> should match the snapshot 1`] = `
   height: 15%;
   background-color: #999;
   border-radius: 100%;
-  -webkit-animation: evVlQQ 1.2s infinite ease-in-out both;
-  animation: evVlQQ 1.2s infinite ease-in-out both;
+  -webkit-animation: klxJsx 1.2s infinite ease-in-out both;
+  animation: klxJsx 1.2s infinite ease-in-out both;
   -webkit-animation-delay: -0.2s;
   -webkit-animation-delay: -0.2s;
   animation-delay: -0.2s;
@@ -329,8 +329,8 @@ exports[`<LoadingIndicator /> should match the snapshot 1`] = `
   height: 15%;
   background-color: #999;
   border-radius: 100%;
-  -webkit-animation: evVlQQ 1.2s infinite ease-in-out both;
-  animation: evVlQQ 1.2s infinite ease-in-out both;
+  -webkit-animation: klxJsx 1.2s infinite ease-in-out both;
+  animation: klxJsx 1.2s infinite ease-in-out both;
   -webkit-animation-delay: -0.1s;
   -webkit-animation-delay: -0.1s;
   animation-delay: -0.1s;

--- a/app/components/ReposList/tests/__snapshots__/index.test.js.snap
+++ b/app/components/ReposList/tests/__snapshots__/index.test.js.snap
@@ -2,49 +2,49 @@
 
 exports[`<ReposList /> should render the loading indicator when its loading 1`] = `
 <div
-  class="Wrapper-sc-1umgotm-0 laCwDT"
+  class="Wrapper-sc-1umgotm-0 ecgSvX"
 >
   <ul
-    class="Ul-mwnq6h-0 jcxXFy"
+    class="Ul-mwnq6h-0 dQQbGm"
   >
     <div
-      class="Wrapper-sc-12uw37d-0 bTWIVF"
+      class="Wrapper-sc-12uw37d-0 kAuqEQ"
     >
       <div
-        class="Circle__CirclePrimitive-ww56dy-0 enQIMS"
+        class="Circle__CirclePrimitive-ww56dy-0 iikEBs"
       />
       <div
-        class="Circle__CirclePrimitive-ww56dy-0 jCxmwS"
+        class="Circle__CirclePrimitive-ww56dy-0 ciMwAF"
       />
       <div
-        class="Circle__CirclePrimitive-ww56dy-0 dyFXB"
+        class="Circle__CirclePrimitive-ww56dy-0 bhCCdw"
       />
       <div
-        class="Circle__CirclePrimitive-ww56dy-0 ikwUeP"
+        class="Circle__CirclePrimitive-ww56dy-0 bfpogp"
       />
       <div
-        class="Circle__CirclePrimitive-ww56dy-0 hwlQRz"
+        class="Circle__CirclePrimitive-ww56dy-0 fRJQBN"
       />
       <div
-        class="Circle__CirclePrimitive-ww56dy-0 jjXxyb"
+        class="Circle__CirclePrimitive-ww56dy-0 cEzRfw"
       />
       <div
-        class="Circle__CirclePrimitive-ww56dy-0 jVExkJ"
+        class="Circle__CirclePrimitive-ww56dy-0 kGLBib"
       />
       <div
-        class="Circle__CirclePrimitive-ww56dy-0 haCVIz"
+        class="Circle__CirclePrimitive-ww56dy-0 jSbSwL"
       />
       <div
-        class="Circle__CirclePrimitive-ww56dy-0 ghhiLZ"
+        class="Circle__CirclePrimitive-ww56dy-0 gERTau"
       />
       <div
-        class="Circle__CirclePrimitive-ww56dy-0 bCbqdt"
+        class="Circle__CirclePrimitive-ww56dy-0 drHTEd"
       />
       <div
-        class="Circle__CirclePrimitive-ww56dy-0 hZPQMA"
+        class="Circle__CirclePrimitive-ww56dy-0 cCYkSN"
       />
       <div
-        class="Circle__CirclePrimitive-ww56dy-0 fsGOmP"
+        class="Circle__CirclePrimitive-ww56dy-0 kFjUVs"
       />
     </div>
   </ul>
@@ -53,34 +53,34 @@ exports[`<ReposList /> should render the loading indicator when its loading 1`] 
 
 exports[`<ReposList /> should render the repositories if loading was successful 1`] = `
 <div
-  class="Wrapper-sc-1umgotm-0 laCwDT"
+  class="Wrapper-sc-1umgotm-0 ecgSvX"
 >
   <ul
-    class="Ul-mwnq6h-0 jcxXFy"
+    class="Ul-mwnq6h-0 dQQbGm"
   >
     <li
-      class="Wrapper-euo0oy-0 jLvxtc"
+      class="Wrapper-euo0oy-0 eJKeOn"
     >
       <div
-        class="Item-sc-3y9mie-0 fKXSkT"
+        class="Item-sc-3y9mie-0 civBtD"
       >
         <div
-          class="Wrapper-sc-17s0rao-0 dlZQhZ"
+          class="Wrapper-sc-17s0rao-0 cpVNCC"
         >
           <a
-            class="A-br8h0y-0 RepoLink-pvpwpn-0 eEveIZ"
+            class="A-br8h0y-0 RepoLink-pvpwpn-0 jnnUwK"
             href="https://github.com/react-boilerplate/react-boilerplate"
             target="_blank"
           >
             react-boilerplate
           </a>
           <a
-            class="A-br8h0y-0 IssueLink-uyzonb-0 kUUUnc"
+            class="A-br8h0y-0 IssueLink-uyzonb-0 hMhivU"
             href="https://github.com/react-boilerplate/react-boilerplate/issues"
             target="_blank"
           >
             <svg
-              class="IssueIcon-s8m34y-0 jEBeEF"
+              class="IssueIcon-s8m34y-0 fJytbt"
               height="1em"
               width="0.875em"
             >

--- a/app/components/Toggle/tests/__snapshots__/index.test.js.snap
+++ b/app/components/Toggle/tests/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Toggle /> should contain default text 1`] = `
 <select
-  class="Select-sc-1sm01tk-0 wIjFa"
+  class="Select-sc-1sm01tk-0 UGvsg"
 >
   <option
     value="en"

--- a/app/containers/App/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/App/tests/__snapshots__/index.test.js.snap
@@ -29,6 +29,6 @@ exports[`<App /> should render and match the snapshot 1`] = `
     />
   </Switch>
   <Footer />
-  <GlobalStyleComponent />
+  <UNDEFINED />
 </ForwardRef(App__AppWrapper)>
 `;

--- a/app/containers/FeaturePage/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/FeaturePage/tests/__snapshots__/index.test.js.snap
@@ -3,20 +3,20 @@
 exports[`<FeaturePage /> should render its heading 1`] = `
 <div>
   <h1
-    class="H1-tncdg6-0 hpAKSC"
+    class="H1-tncdg6-0 btKuGt"
   >
     <span>
       Features
     </span>
   </h1>
   <ul
-    class="List-sc-1aai6b-0 gbaodI"
+    class="List-sc-1aai6b-0 hOYEsl"
   >
     <li
-      class="ListItem-sc-27v6xc-0 fixMwZ"
+      class="ListItem-sc-27v6xc-0 frRZJi"
     >
       <p
-        class="ListItemTitle-sc-1t4skn3-0 fWjsMZ"
+        class="ListItemTitle-sc-1t4skn3-0 iygOss"
       >
         <span>
           Quick scaffolding
@@ -30,10 +30,10 @@ exports[`<FeaturePage /> should render its heading 1`] = `
       </p>
     </li>
     <li
-      class="ListItem-sc-27v6xc-0 fixMwZ"
+      class="ListItem-sc-27v6xc-0 frRZJi"
     >
       <p
-        class="ListItemTitle-sc-1t4skn3-0 fWjsMZ"
+        class="ListItemTitle-sc-1t4skn3-0 iygOss"
       >
         <span>
           Instant feedback
@@ -51,10 +51,10 @@ exports[`<FeaturePage /> should render its heading 1`] = `
       </p>
     </li>
     <li
-      class="ListItem-sc-27v6xc-0 fixMwZ"
+      class="ListItem-sc-27v6xc-0 frRZJi"
     >
       <p
-        class="ListItemTitle-sc-1t4skn3-0 fWjsMZ"
+        class="ListItemTitle-sc-1t4skn3-0 iygOss"
       >
         <span>
           Industry-standard routing
@@ -72,10 +72,10 @@ exports[`<FeaturePage /> should render its heading 1`] = `
       </p>
     </li>
     <li
-      class="ListItem-sc-27v6xc-0 fixMwZ"
+      class="ListItem-sc-27v6xc-0 frRZJi"
     >
       <p
-        class="ListItemTitle-sc-1t4skn3-0 fWjsMZ"
+        class="ListItemTitle-sc-1t4skn3-0 iygOss"
       >
         <span>
           Offline-first
@@ -91,10 +91,10 @@ exports[`<FeaturePage /> should render its heading 1`] = `
       </p>
     </li>
     <li
-      class="ListItem-sc-27v6xc-0 fixMwZ"
+      class="ListItem-sc-27v6xc-0 frRZJi"
     >
       <p
-        class="ListItemTitle-sc-1t4skn3-0 fWjsMZ"
+        class="ListItemTitle-sc-1t4skn3-0 iygOss"
       >
         <span>
           Complete i18n Standard Internationalization & Pluralization

--- a/app/containers/HomePage/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/HomePage/tests/__snapshots__/index.test.js.snap
@@ -4,10 +4,10 @@ exports[`<HomePage /> should render and match the snapshot 1`] = `
 <article>
   <div>
     <section
-      class="Section-sc-1eulrsm-0 CenteredSection-sc-6zy0wx-0 imGCbL"
+      class="Section-sc-1eulrsm-0 CenteredSection-sc-6zy0wx-0 fqjcmt"
     >
       <h2
-        class="H2-egphza-0 HsCXl"
+        class="H2-egphza-0 kOBPCJ"
       >
         <span>
           Start your next react project in seconds
@@ -20,17 +20,17 @@ exports[`<HomePage /> should render and match the snapshot 1`] = `
       </p>
     </section>
     <section
-      class="Section-sc-1eulrsm-0 eTEsZl"
+      class="Section-sc-1eulrsm-0 enlKrc"
     >
       <h2
-        class="H2-egphza-0 HsCXl"
+        class="H2-egphza-0 kOBPCJ"
       >
         <span>
           Try me!
         </span>
       </h2>
       <form
-        class="Form-dmhz4x-0 ZClLh"
+        class="Form-dmhz4x-0 fgLKqB"
       >
         <label
           for="username"
@@ -39,14 +39,14 @@ exports[`<HomePage /> should render and match the snapshot 1`] = `
             Show Github repositories by
           </span>
           <span
-            class="AtPrefix-sc-1suuq8o-0 fvrDQr"
+            class="AtPrefix-sc-1suuq8o-0 gGypRq"
           >
             <span>
               @
             </span>
           </span>
           <input
-            class="Input-sc-19rkjmi-0 gyJaEd"
+            class="Input-sc-19rkjmi-0 gdyJXH"
             id="username"
             placeholder="mxstbr"
             type="text"

--- a/app/containers/LocaleToggle/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/LocaleToggle/tests/__snapshots__/index.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`<LocaleToggle /> should match the snapshot 1`] = `
 <div
-  class="Wrapper-xnjoq9-0 dNmQIR"
+  class="Wrapper-xnjoq9-0 jdNcyG"
 >
   <select
-    class="Select-sc-1sm01tk-0 wIjFa"
+    class="Select-sc-1sm01tk-0 UGvsg"
   >
     <option
       value="en"

--- a/app/containers/RepoListItem/tests/__snapshots__/IssueLink.test.js.snap
+++ b/app/containers/RepoListItem/tests/__snapshots__/IssueLink.test.js.snap
@@ -25,7 +25,7 @@ exports[`<IssueLink /> should match the snapshot 1`] = `
 }
 
 <a
-  class="c0"
+  class="A-br8h0y-0 c0"
 >
   Test
 </a>

--- a/app/containers/RepoListItem/tests/__snapshots__/RepoLink.test.js.snap
+++ b/app/containers/RepoListItem/tests/__snapshots__/RepoLink.test.js.snap
@@ -21,7 +21,7 @@ exports[`<RepoLink /> should match the snapshot 1`] = `
 }
 
 <a
-  class="c0"
+  class="A-br8h0y-0 c0"
 >
   Test
 </a>

--- a/app/containers/RepoListItem/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/RepoListItem/tests/__snapshots__/index.test.js.snap
@@ -2,28 +2,28 @@
 
 exports[`<RepoListItem /> should render a ListItem 1`] = `
 <li
-  class="Wrapper-euo0oy-0 jLvxtc"
+  class="Wrapper-euo0oy-0 eJKeOn"
 >
   <div
-    class="Item-sc-3y9mie-0 fKXSkT"
+    class="Item-sc-3y9mie-0 civBtD"
   >
     <div
-      class="Wrapper-sc-17s0rao-0 dlZQhZ"
+      class="Wrapper-sc-17s0rao-0 cpVNCC"
     >
       <a
-        class="A-br8h0y-0 RepoLink-pvpwpn-0 eEveIZ"
+        class="A-br8h0y-0 RepoLink-pvpwpn-0 jnnUwK"
         href="https://github.com/react-boilerplate/react-boilerplate"
         target="_blank"
       >
         react-boilerplate/react-boilerplate
       </a>
       <a
-        class="A-br8h0y-0 IssueLink-uyzonb-0 kUUUnc"
+        class="A-br8h0y-0 IssueLink-uyzonb-0 hMhivU"
         href="https://github.com/react-boilerplate/react-boilerplate/issues"
         target="_blank"
       >
         <svg
-          class="IssueIcon-s8m34y-0 jEBeEF"
+          class="IssueIcon-s8m34y-0 fJytbt"
           height="1em"
           width="0.875em"
         >

--- a/internals/templates/containers/App/tests/__snapshots__/index.test.js.snap
+++ b/internals/templates/containers/App/tests/__snapshots__/index.test.js.snap
@@ -12,6 +12,6 @@ exports[`<App /> should render and match the snapshot 1`] = `
       component={[Function]}
     />
   </Switch>
-  <GlobalStyleComponent />
+  <UNDEFINED />
 </div>
 `;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1063,22 +1063,27 @@
       }
     },
     "@emotion/is-prop-valid": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.5.tgz",
-      "integrity": "sha512-6ZODuZSFofbxSbcxwsFz+6ioPjb0ISJRRPLZ+WIbjcU2IMU0Io+RGQjjaTgOvNQl007KICBm7zXQaYQEC1r6Bg==",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.6.tgz",
+      "integrity": "sha512-mnZMho3Sq8BfzkYYRVc8ilQTnc8U02Ytp6J1AwM6taQStZ3AhsEJBX2LzhA/LJirNCwM2VtHL3VFIZ+sNJUgUQ==",
       "requires": {
-        "@emotion/memoize": "0.7.3"
+        "@emotion/memoize": "0.7.4"
       }
     },
     "@emotion/memoize": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.3.tgz",
-      "integrity": "sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow=="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
     },
     "@emotion/unitless": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.4.tgz",
-      "integrity": "sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ=="
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@hot-loader/react-dom": {
       "version": "16.11.0",
@@ -5544,13 +5549,13 @@
       "optional": true
     },
     "css-to-react-native": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
-      "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^3.3.0"
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "css-tree": {
@@ -10507,11 +10512,6 @@
       "dev": true,
       "optional": true
     },
-    "is-what": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.4.0.tgz",
-      "integrity": "sha512-oFdBRuSY9PocqPoUUseDXek4I+A1kWGigZGhuG+7GEkp0tRkek11adc0HbTEVsNvtojV7rp0uhf5LWtGvHzoOQ=="
-    },
     "is-whitespace-character": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
@@ -11613,9 +11613,9 @@
       }
     },
     "jest-styled-components": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-6.3.4.tgz",
-      "integrity": "sha512-dc32l0/6n3FtsILODpvKNz6SLg50OmbJ/3r3oRh9jc2VIPPGZT5jWv7BKIcNCYH7E38ZK7uejNl3zJsCOIenng==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-7.0.0.tgz",
+      "integrity": "sha512-A1nl8q1ptZj1t5wd0x/UYjnqfld1GhZwRDPS9w0eD5P5R8G+Q4uHaBAbUjf+Arjexqh2BxfrGkTc3tDuhtdifg==",
       "dev": true,
       "requires": {
         "css": "^2.2.4"
@@ -13125,11 +13125,6 @@
         }
       }
     },
-    "memoize-one": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
-    },
     "memory-fs": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
@@ -13280,14 +13275,6 @@
             "get-stdin": "^4.0.1"
           }
         }
-      }
-    },
-    "merge-anything": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.4.2.tgz",
-      "integrity": "sha512-/so+4seX7fdAhPI3m3bxwc60vhotzY9uM+1Z6C3GKeJBYzxt/lIrbs5uT9iwgM5aLi5kpJIPT7JzJfrrfloWHA==",
-      "requires": {
-        "is-what": "^3.3.1"
       }
     },
     "merge-descriptors": {
@@ -15535,9 +15522,9 @@
       "dev": true
     },
     "postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+      "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ=="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -18044,22 +18031,19 @@
       "dev": true
     },
     "styled-components": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.4.1.tgz",
-      "integrity": "sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.0.0.tgz",
+      "integrity": "sha512-F7VhIXIbUXJ8KO3pU9wap2Hxdtqa6PZ1uHrx+YXTgRjyxGlwvBHb8LULXPabmDA+uEliTXRJM5WcZntJnKNn3g==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@emotion/is-prop-valid": "^0.8.1",
-        "@emotion/unitless": "^0.7.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^0.8.3",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
         "babel-plugin-styled-components": ">= 1",
-        "css-to-react-native": "^2.2.2",
-        "memoize-one": "^5.0.0",
-        "merge-anything": "^2.2.4",
-        "prop-types": "^15.5.4",
-        "react-is": "^16.6.0",
-        "stylis": "^3.5.0",
-        "stylis-rule-sheet": "^0.0.10",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
         "supports-color": "^5.5.0"
       },
       "dependencies": {
@@ -18578,16 +18562,6 @@
           }
         }
       }
-    },
-    "stylis": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
-    },
-    "stylis-rule-sheet": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
     },
     "sugarss": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -85,11 +85,11 @@
     "react-redux": "7.1.3",
     "react-router-dom": "5.1.2",
     "redux": "4.0.4",
-    "redux-saga": "1.1.3",
     "redux-injectors": "1.2.0",
+    "redux-saga": "1.1.3",
     "reselect": "4.0.0",
     "sanitize.css": "11.0.0",
-    "styled-components": "4.4.1"
+    "styled-components": "5.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.7.4",
@@ -137,7 +137,7 @@
     "image-webpack-loader": "6.0.0",
     "imports-loader": "0.8.0",
     "jest-cli": "24.9.0",
-    "jest-styled-components": "6.3.4",
+    "jest-styled-components": "7.0.0",
     "jest-watch-typeahead": "0.4.2",
     "lint-staged": "9.4.3",
     "ngrok": "3.2.5",


### PR DESCRIPTION
This PR upgrades `styled-components` and `jest-styled-components` to the latest major version. The new version has no braking changes.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
- [x] Double-check your branch is based on `dev` and targets `dev` 
