### PR TITLE
Switch to network-first response strategy in offline-plugin

### DIFF
--- a/docs/general/README.md
+++ b/docs/general/README.md
@@ -88,6 +88,9 @@ connection from the instant your users load the app. This is done with a
 ServiceWorker and a fallback to AppCache, so this feature even works on older
 browsers!
 
+> For better performance you can switch to [cache-first](https://github.com/NekR/offline-plugin/blob/master/docs/options.md#responsestrategy-cache-first--network-first) strategy.
+> You can also force update the SW/AppCache by following the [instructions](https://github.com/NekR/offline-plugin/blob/master/docs/updates.md), which will avoid delayed updating problems for the new deployments
+
 > All your files are included automatically. No manual intervention needed
 > thanks to Webpack's [`offline-plugin`](https://github.com/NekR/offline-plugin)
 

--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -82,6 +82,9 @@ module.exports = require('./webpack.base.babel')({
     // Put it in the end to capture all the HtmlWebpackPlugin's
     // assets manipulations and do leak its manipulations to HtmlWebpackPlugin
     new OfflinePlugin({
+      // replace with 'cache-first' for faster performance. See https://github.com/NekR/offline-plugin/blob/master/docs/options.md#responsestrategy-cache-first--network-first
+      responseStrategy: 'network-first',
+
       relativePaths: false,
       publicPath: '/',
       appShell: '/',


### PR DESCRIPTION
The default `cache-first` strategy of the `offline-plugin` is a general problem as seen in #2750  and this [solution](https://github.com/react-boilerplate/react-boilerplate/issues/2750#issuecomment-536215256) prevents this

**Changes:**
- Switched to `network-first` strategy
- Added notes to `docs` some gotchas and reference links

