### PR TITLE
fix: tree-shaking

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -116,7 +116,6 @@ module.exports = options => ({
   resolve: {
     modules: ['node_modules', 'app'],
     extensions: ['.js', '.jsx', '.react.js'],
-    mainFields: ['browser', 'jsnext:main', 'main'],
     alias: {
       'react-dom': '@hot-loader/react-dom',
     },


### PR DESCRIPTION
Fixing tree-shaking problems => #2880 #2835 

`jsnext:main`(which is [deprecated](https://github.com/jsforum/jsforum/issues/5)) is ruining the es6 modules resolution. Default value should be used so I removed it. 

See the [doc](https://webpack.js.org/configuration/resolve/#resolve-mainfields)