### PR TITLE
feat(server): Add X-Powered-By: react-boilerpace to the response header by default

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -32,6 +32,7 @@ const prettyHost = customHost || 'localhost';
 app.get('*.js', (req, res, next) => {
   req.url = req.url + '.gz'; // eslint-disable-line
   res.set('Content-Encoding', 'gzip');
+  res.setHeader('X-Powered-By', 'react-boilerplate');
   next();
 });
 


### PR DESCRIPTION
## Feature Request

Is your feature request related to a problem? Please describe.
Most backend frameworks store the information with which technology the site has been built with the response header.
You can see examples of other technologies using this header in the app.json of Wappalyzer and search for `X-Powered-By`

Once we have implemented this, tools like Wappalyzer then can use this information to determine how the site has been built.

## Describe the solution you'd like
By default, every application built with `react-boilerplace` should have this information.

## Teachability, Documentation, Adoption, Migration Strategy
This will override the X-Powered-By: `react-boilerplace` information. Though I don't think we should consider this as breaking change since very very few applications could be affected by this change

## What is the motivation / use case for changing the behavior?
- Traceability
- Promotion