### PR TITLE
fix: remove propTypes import in prod build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -19,7 +19,12 @@ module.exports = {
       only: ['app'],
       plugins: [
         'lodash',
-        'transform-react-remove-prop-types',
+        [
+          'transform-react-remove-prop-types',
+          {
+            removeImport: true
+          }
+        ],
         '@babel/plugin-transform-react-inline-elements',
         '@babel/plugin-transform-react-constant-elements',
       ],


### PR DESCRIPTION
# Description
Remove prop-types imported to prod build

`import PropTypes from ‘prop-types’`
The above gets added in the prod build.

`transform-react-remove-prop-types` in the babel config removes the propTypes added but fails to remove the propTypes imported at the top of the scope.

It requires `removeImport: true` configuration in `transform-react-remove-prop-types`  to be able to remove the propTypes import at the top of scope

# Steps to reproduce
1. Add @babel/cli package to be able to test the babel config.
`npm install @babel/cli --save-dev`
(or)
`yarn add -D @babel/cli`

2. Set the NODE_ENV to production
This is required to test the configs for production
`export NODE_ENV=production`

3. Choose a file that you would like test
I have chosen the `index.js` file in `app/containers/HomePage` directory

4. Use babel to execute the file
`npx babel app/containers/HomePage/index.js`

# Screenshots
With dev branch
<img width="883" alt="Screenshot 2023-01-15 at 1 17 26 PM" src="https://user-images.githubusercontent.com/62658404/212533762-29e5ab1a-82fb-41c4-a31e-7ba8546b7d25.png">


With changes fixed in PR
<img width="901" alt="Screenshot 2023-01-15 at 1 16 31 PM" src="https://user-images.githubusercontent.com/62658404/212533770-e7f8235b-b2a0-4c72-b695-b3d32f56d93b.png">
